### PR TITLE
Move task from gpdb to this repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+## ======================================================================
+##                     greenplum-database-release - Makefile
+## ======================================================================
+## Variables
+## ======================================================================
+
+# set the concourse target default to dev
+ifndef CONCOURSE
+override CONCOURSE  = dev
+endif
+
+# set the gp-release default branch to current branch
+ifndef BRANCH
+override BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+endif
+
+PIPELINE_NAME              = greenplum-database-release-${BRANCH}-${USER}
+FLY_CMD                    = fly
+FLY_OPTION_NON-INTERACTIVE =
+
+.PHONY: set-dev set-pipeline-dev destroy-dev destroy-pipeline-dev set-prod set-pipeline-prod
+
+## ----------------------------------------------------------------------
+## List explicit rules
+## ----------------------------------------------------------------------
+
+list:
+	@sh -c "$(MAKE) -p no_targets__ 2>/dev/null | \
+	awk -F':' '/^[a-zA-Z0-9][^\$$#\/\\t=]*:([^=]|$$)/ {split(\$$1,A,/ /);for(i in A)print A[i]}' | \
+	grep -v Makefile | \
+	grep -v '%' | \
+	grep -v '__\$$' | \
+	sort"
+
+## ----------------------------------------------------------------------
+## Set Development Pipeline
+## ----------------------------------------------------------------------
+
+set-dev: set-pipeline-dev
+
+set-pipeline-dev:
+
+	sed -e 's|tag_filter: *|## tag_filter: |g' concourse/pipelines/gpdb_opensource_release.yml > concourse/pipelines/${PIPELINE_NAME}.yml
+
+	$(FLY_CMD) --target=${CONCOURSE} \
+    set-pipeline \
+    --pipeline=${PIPELINE_NAME} \
+    --config=concourse/pipelines/${PIPELINE_NAME}.yml \
+    --load-vars-from=${HOME}/workspace/gp-continuous-integration/secrets/gpdb-oss-release.dev.yml  \
+    --var=greenplum-database-release-git-branch=${BRANCH} \
+    --var=greenplum-database-release-git-remote=https://github.com/greenplum-db/greenplum-database-release.git \
+    --var=pipeline-name=${PIPELINE_NAME} \
+    ${FLY_OPTION_NON-INTERACTIVE}
+
+	@echo using the following command to unpause the pipeline:
+	@echo "\t$(FLY_CMD) -t ${CONCOURSE} unpause-pipeline --pipeline ${PIPELINE_NAME}"
+
+## ----------------------------------------------------------------------
+## Destroy Development Pipeline
+## ----------------------------------------------------------------------
+
+destroy-dev: destroy-pipeline-dev
+
+destroy-pipeline-dev:
+	$(FLY_CMD) --target=${CONCOURSE} \
+    destroy-pipeline \
+    --pipeline=${PIPELINE_NAME} \
+    ${FLY_OPTION_NON-INTERACTIVE}
+
+## ----------------------------------------------------------------------
+## Set Production Pipeline
+## ----------------------------------------------------------------------
+
+set-prod: set-pipeline-prod
+
+set-pipeline-prod:
+	$(FLY_CMD) --target=prod \
+    set-pipeline \
+    --pipeline=greenplum-database-release \
+    --config=concourse/pipelines/gpdb_opensource_release.yml \
+    --load-vars-from=${HOME}/workspace/gp-continuous-integration/secrets/gpdb-oss-release.prod.yml  \
+    --var=pipeline-name=greenplum-database-release \
+    --var=greenplum-database-release-git-branch=master \
+    --var=greenplum-database-release-git-remote=https://github.com/greenplum-db/greenplum-database-release.git \
+    ${FLY_OPTION_NON-INTERACTIVE}
+
+	@echo using the following command to unpause the pipeline:
+	@echo "\t$(FLY_CMD) -t prod unpause-pipeline --pipeline 6X-release"

--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -231,6 +231,7 @@ jobs:
           - get: bin_gpdb_ubuntu18.04
             passed: [compile_gpdb_ubuntu18.04]
           - get: gpdb6-ubuntu18.04-build
+          - get: license_file
       # Even though we don't ship the QA utils, we still need to strip out non-shipping files
       - task: separate_qautils_files_for_rc_ubuntu18.04
         file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml

--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -1,0 +1,337 @@
+resource_types:
+  - name: gcs
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource
+
+resources:
+  ## Image Resources
+  - name: gpdb6-centos6-build
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb6-centos6-build
+      tag: 'latest'
+
+  - name: gpdb6-centos7-build
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb6-centos7-build
+      tag: 'latest'
+
+  - name: gpdb6-ubuntu18.04-build
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb6-ubuntu18.04-build
+      tag: 'latest'
+
+  - name: gpdb_src
+    type: git
+    source:
+      branch: ((gpdb-git-branch))
+      uri: ((gpdb-git-remote))
+      tag_filter: ((gpdb-git-tag-filter))
+
+  - name: greenplum-database-release_src
+    type: git
+    source:
+      branch: ((greenplum-database-release-git-branch))
+      uri: ((greenplum-database-release-git-remote))
+
+  - name: gpdb_release
+    type: github-release
+    source:
+      owner: ((gpdb-release-owner))
+      repository: ((gpdb-release-repository))
+      access_token: ((gpdb-release-access-token))
+
+  - name: license_file
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-for-oss))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: osl/released/gpdb6/open_source_license_greenplum-database-(.*)-[a-z0-9]+-[0-9]+.txt
+
+  ## gp internal artifacts
+  - name: python-centos6
+    type: gcs
+    source:
+      bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
+      json_key: ((gcs-key))
+      versioned_file: centos6/python-2.7.12.tar.gz
+
+  - name: python-centos7
+    type: gcs
+    source:
+      bucket: ((pivotal-gp-internal-artifacts-gcs-bucket))
+      json_key: ((gcs-key))
+      versioned_file: centos7/python-2.7.12.tar.gz
+
+  - name: python-ubuntu18.04
+    type: gcs
+    source:
+      bucket: gp-internal-artifacts
+      json_key: ((gcs-key))
+      versioned_file: ubuntu18.04/python-2.7.12.tar.gz
+
+  ## RHEL6 Resources
+  - name: bin_gpdb_centos6
+    type: gcs
+    source:
+      json_key: {{concourse-gcs-resources-service-account-key}}
+      bucket: {{gcs-bucket-intermediates-for-oss}}
+      versioned_file: ((pipeline-name))/bin_gpdb_centos6/bin_gpdb.tar.gz
+
+  - name: bin_gpdb_centos6_release
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-for-oss))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: greenplum-oss-server/released/gpdb6/server-(.*)-rhel6_x86_64.tar.gz
+
+  ## RHEL7 Resources
+  - name: bin_gpdb_centos7
+    type: gcs
+    source:
+      json_key: {{concourse-gcs-resources-service-account-key}}
+      bucket: {{gcs-bucket-intermediates-for-oss}}
+      versioned_file: ((pipeline-name))/bin_gpdb_centos7/bin_gpdb.tar.gz
+
+  - name: bin_gpdb_centos7_release
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-for-oss))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: greenplum-oss-server/released/gpdb6/server-(.*)-rhel7_x86_64.tar.gz
+
+  ## Ubuntu18.04 Resources
+  - name: bin_gpdb_ubuntu18.04
+    type: gcs
+    source:
+      json_key: {{concourse-gcs-resources-service-account-key}}
+      bucket: {{gcs-bucket-intermediates-for-oss}}
+      versioned_file: ((pipeline-name))/bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
+
+  - name: bin_gpdb_ubuntu18.04_release
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-for-oss))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: greenplum-oss-server/released/gpdb6/server-(.*)-ubuntu18.04_x86_64.tar.gz
+
+  - name: gpdb_debian_package
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-for-oss))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: greenplum-oss-server/released/gpdb6/greenplum-db-(.*)-ubuntu18.04-amd64.deb
+
+jobs:
+  - name: compile_gpdb_centos6
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+          - get: greenplum-database-release_src
+          - get: gpdb6-centos6-build
+          - get: python-tarball
+            resource: python-centos6
+      - task: compile_gpdb
+        file: greenplum-database-release_src/concourse/tasks/compile_gpdb_oss.yml
+        image: gpdb6-centos6-build
+      - put: bin_gpdb_centos6
+        params:
+          file: gpdb_artifacts/bin_gpdb.tar.gz
+
+  - name: compile_gpdb_centos7
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+          - get: greenplum-database-release_src
+          - get: gpdb6-centos7-build
+          - get: python-tarball
+            resource: python-centos7
+      - task: compile_gpdb
+        image: gpdb6-centos7-build
+        file: greenplum-database-release_src/concourse/tasks/compile_gpdb_oss.yml
+      - put: bin_gpdb_centos7
+        params:
+          file: gpdb_artifacts/bin_gpdb.tar.gz
+
+  - name: compile_gpdb_ubuntu18.04
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+          - get: greenplum-database-release_src
+          - get: gpdb6-ubuntu18.04-build
+          - get: python-tarball
+            resource: python-ubuntu18.04
+      - task: compile_gpdb
+        image: gpdb6-ubuntu18.04-build
+        file: greenplum-database-release_src/concourse/tasks/compile_gpdb_oss.yml
+      - put:  bin_gpdb_ubuntu18.04
+        params:
+          file: gpdb_artifacts/bin_gpdb.tar.gz
+
+  - name: create_gpdb_tarball_centos6
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+            passed: [compile_gpdb_centos6]
+          - get: bin_gpdb_centos6
+            passed: [compile_gpdb_centos6]
+          - get: gpdb6-centos6-build
+      # Even though we don't ship the QA utils, we still need to strip out non-shipping files
+      - task: separate_qautils_files_for_rc_centos6
+        file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
+        image: gpdb6-centos6-build
+        input_mapping:
+          bin_gpdb: bin_gpdb_centos6
+        output_mapping:
+          rc_bin_gpdb: rc_bin_gpdb_rhel6
+        params:
+          QAUTILS_TARBALL: "rc_bin_gpdb/QAUtils-rhel6-x86_64.tar.gz"
+      - put: bin_gpdb_centos6
+        params:
+          file: rc_bin_gpdb_rhel6/bin_gpdb.tar.gz
+
+  - name: create_gpdb_tarball_centos7
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+            passed: [compile_gpdb_centos7]
+          - get: bin_gpdb_centos7
+            passed: [compile_gpdb_centos7]
+          - get: gpdb6-centos7-build
+      # Even though we don't ship the QA utils, we still need to strip out non-shipping files
+      - task: separate_qautils_files_for_rc_centos7
+        file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
+        image: gpdb6-centos7-build
+        input_mapping:
+          bin_gpdb: bin_gpdb_centos7
+        output_mapping:
+          rc_bin_gpdb: rc_bin_gpdb_rhel7
+        params:
+          QAUTILS_TARBALL: "rc_bin_gpdb/QAUtils-rhel7-x86_64.tar.gz"
+      - put: bin_gpdb_centos7
+        params:
+          file: rc_bin_gpdb_rhel7/bin_gpdb.tar.gz
+
+  - name: ubuntu18.04 packaging
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+            passed: [compile_gpdb_ubuntu18.04]
+          - get: greenplum-database-release_src
+            passed: [compile_gpdb_ubuntu18.04]
+          - get: bin_gpdb_ubuntu18.04
+            passed: [compile_gpdb_ubuntu18.04]
+          - get: gpdb6-ubuntu18.04-build
+      # Even though we don't ship the QA utils, we still need to strip out non-shipping files
+      - task: separate_qautils_files_for_rc_ubuntu18.04
+        file: gpdb_src/concourse/tasks/separate_qautils_files_for_rc.yml
+        image: gpdb6-ubuntu18.04-build
+        input_mapping:
+          bin_gpdb: bin_gpdb_ubuntu18.04
+        output_mapping:
+          rc_bin_gpdb: rc_bin_gpdb_ubuntu18.04
+        params:
+          QAUTILS_TARBALL: "rc_bin_gpdb/QAUtils-ubuntu18.04-amd64.tar.gz"
+      - task: create_gpdb_debian_package
+        file: greenplum-database-release_src/concourse/tasks/build_gpdb_debian.yml
+        image: gpdb6-ubuntu18.04-build
+        input_mapping:
+          bin_gpdb: rc_bin_gpdb_ubuntu18.04
+        params:
+          PLATFORM: "ubuntu18.04"
+      - aggregate:
+        - put: bin_gpdb_ubuntu18.04
+          params:
+            file: rc_bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
+        - put: gpdb_debian_package
+          params:
+            file: gpdb_debian_installer/*.deb
+
+  - name: release
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            passed:
+              - create_gpdb_tarball_centos6
+              - create_gpdb_tarball_centos7
+              - ubuntu18.04 packaging
+          - get: bin_gpdb_centos6
+            passed: [create_gpdb_tarball_centos6]
+            trigger: true
+          - get: bin_gpdb_centos7
+            passed: [create_gpdb_tarball_centos7]
+            trigger: true
+          - get: bin_gpdb_ubuntu18.04
+            passed: [ubuntu18.04 packaging]
+            trigger: true
+          - get: gpdb_debian_package
+            passed: [ubuntu18.04 packaging]
+          - get: gpdb6-centos6-build
+      - task: rename_gpdb_tarball
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: pivotaldata/gpdb6-centos6-build
+          inputs:
+            - name: gpdb_src
+            - name: bin_gpdb_centos6
+            - name: bin_gpdb_centos7
+            - name: bin_gpdb_ubuntu18.04
+          outputs:
+            - name: releases
+          run:
+            path: bash
+            args:
+              - -ec
+              - |
+                gpdb_semver=$(gpdb_src/getversion | cut -d' ' -f1)
+                cp -v bin_gpdb_centos6/bin_gpdb.tar.gz releases/server-${gpdb_semver}-rhel6_x86_64.tar.gz
+                cp -v bin_gpdb_centos7/bin_gpdb.tar.gz releases/server-${gpdb_semver}-rhel7_x86_64.tar.gz
+                cp -v bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz releases/server-${gpdb_semver}-ubuntu18.04_x86_64.tar.gz
+      - task: verify_gpdb_versions
+        file: gpdb_src/concourse/tasks/verify_gpdb_versions.yml
+      - aggregate:
+          - put: bin_gpdb_centos6_release
+            params:
+              file: "releases/server-*rhel6*.tar.gz"
+          - put: bin_gpdb_centos7_release
+            params:
+              file: "releases/server-*rhel7*.tar.gz"
+          - put: bin_gpdb_ubuntu18.04_release
+            params:
+              file: "releases/server-*ubuntu18.04*.tar.gz"
+
+  - name: publish_gpdb_github_release
+    plan:
+      - aggregate:
+          - get: gpdb_src
+            trigger: true
+            passed: [release]
+          - get: license_file
+          - get: gpdb_debian_package
+            passed: [release]
+          - get: greenplum-database-release_src
+      - task: gpdb_github_release
+        file: greenplum-database-release_src/concourse/tasks/gpdb_github_release.yml
+      - put: gpdb_release
+        params:
+          name: release_artifacts/name
+          tag: release_artifacts/tag
+          body: release_artifacts/body
+          commitish: release_artifacts/commitish
+          globs:
+            - release_artifacts/*.tar.gz
+            - release_artifacts/*.zip
+            - license_file/*.txt
+            - gpdb_debian_package/*.deb

--- a/concourse/scripts/build_gpdb_debian.bash
+++ b/concourse/scripts/build_gpdb_debian.bash
@@ -28,9 +28,9 @@ rm -f ${GPDB_PREFIX}/${GPDB_NAME}
 exit 0
 EOF
 	chmod 0775 "${__package_name}/DEBIAN/postrm"
-	cat <<EOF >"${__package_name}/DEBIAN/copyright"
-License: ${GPDB_LICENSE}
-EOF
+	mkdir -p "${__package_name}/usr/share/doc/greenplum-db/"
+	cp ../license_file/*.txt "${__package_name}/usr/share/doc/greenplum-db/copyright"
+
 	cat <<EOF >"${__package_name}/DEBIAN/control"
 Package: greenplum-db
 Priority: extra

--- a/concourse/scripts/build_gpdb_debian.bash
+++ b/concourse/scripts/build_gpdb_debian.bash
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+
+function build_debian() {
+
+	local __package_name=$1
+	local __gpdb_binary_tarbal=$2
+
+	mkdir -p "debian_build_dir"
+
+	pushd "debian_build_dir"
+	mkdir -p "${__package_name}/DEBIAN"
+	cat <<EOF >"${__package_name}/DEBIAN/postinst"
+#!/bin/sh
+set -e
+cd ${GPDB_PREFIX}/
+rm -f ${GPDB_NAME}
+ln -s ${GPDB_NAME}-${GPDB_VERSION} ${GPDB_NAME}
+exit 0
+EOF
+	chmod 0775 "${__package_name}/DEBIAN/postinst"
+	cat <<EOF >"${__package_name}/DEBIAN/postrm"
+#!/bin/sh
+set -e
+rm -f ${GPDB_PREFIX}/${GPDB_NAME}
+exit 0
+EOF
+	chmod 0775 "${__package_name}/DEBIAN/postrm"
+	cat <<EOF >"${__package_name}/DEBIAN/copyright"
+License: ${GPDB_LICENSE}
+EOF
+	cat <<EOF >"${__package_name}/DEBIAN/control"
+Package: greenplum-db
+Priority: extra
+Maintainer: gp-releng@pivotal.io
+Architecture: ${GPDB_BUILDARCH}
+Version: ${GPDB_VERSION}
+Provides: Pivotal
+Description: ${GPDB_DESCRIPTION}
+Homepage: ${GPDB_URL}
+Depends: libapr1,
+    libaprutil1,
+    bash,
+    bzip2,
+    krb5-multidev,
+    libcurl3-gnutls,
+    libcurl4,
+    libedit2,
+    libevent-2.1-6,
+    libxml2,
+    libyaml-0-2,
+    zlib1g,
+    libldap-2.4-2,
+    openssh-client,
+    openssh-client,
+    openssl,
+    perl,
+    sed,
+    tar,
+    zip,
+    net-tools,
+    less,
+    iproute2
+EOF
+
+	mkdir -p "${__package_name}/${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}"
+	tar -xf "../${__gpdb_binary_tarbal}" -C "${__package_name}/${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}"
+	sed -i -e "1 s~^\(GPHOME=\).*~\1$GPDB_PREFIX/$GPDB_NAME-$GPDB_VERSION~" "${__package_name}/${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}/greenplum_path.sh"
+	dpkg-deb --build "${__package_name}"
+	popd
+
+	cp "debian_build_dir/${__package_name}.deb" gpdb_debian_installer/
+}
+
+function _main() {
+	local __final_debian_name
+	local __final_package_name
+	local __built_debian
+
+	if [[ -z "${GPDB_VERSION}" ]]; then
+		export GPDB_VERSION="$(./gpdb_src/getversion --short | grep -Po '^[^+]*')"
+	fi
+	echo "[INFO] Building debian installer for GPDB version: ${GPDB_VERSION}"
+
+	echo "[INFO] Building for platform: ${PLATFORM}"
+
+	# Build the expected debian name based on the gpdb version of the artifacts
+	__final_debian_name="greenplum-db-${GPDB_VERSION}-${PLATFORM}-amd64.deb"
+	echo "[INFO] Final debian name: ${__final_debian_name}"
+
+	# Strip the last .deb from the __final_debian_name
+	__final_package_name="${__final_debian_name%.*}"
+	# Setup a location to build debian
+
+    # compared to gp-integration-testing pipeline, gp-release pipeline has different contents for bin_gpdb directory
+    # for gp-integration-testing, say bin_gpdb/server-rc-6.0.0-beta.3+dev.192.g753594a-ubuntu18.04_x86_64.tar.gz
+    # while gp-release, say bin_gpdb/QAUtils-ubuntu18.04-amd64.tar.gz and bin_gpdb/bin_gpdb.tar.gz
+	if [[ -f bin_gpdb/bin_gpdb.tar.gz ]]; then
+        build_debian "${__final_package_name}" bin_gpdb/bin_gpdb.tar.gz
+    else
+        build_debian "${__final_package_name}" bin_gpdb/server-*.tar.gz
+    fi
+	# Export the built debian and include a sha256 hash
+	__built_debian="gpdb_debian_installer/${__final_debian_name}"
+	openssl dgst -sha256 "${__built_debian}" >"${__built_debian}".sha256 || exit 1
+	echo "[INFO] Final Debian installer: ${__built_debian}"
+	echo "[INFO] Final Debian installer sha: $(cat "${__built_debian}".sha256)" || exit 1
+}
+
+_main || exit 1

--- a/concourse/scripts/compile_gpdb_oss.bash
+++ b/concourse/scripts/compile_gpdb_oss.bash
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+fetch_orca_src () {
+    local orca_tag="${1}"
+
+    echo "Downloading greenplum-db/gporca@${orca_tag}"
+    mkdir orca_src
+    wget --quiet --output-document=- "https://github.com/greenplum-db/gporca/archive/${orca_tag}.tar.gz" \
+        | tar xzf - --strip-components=1 --directory=orca_src
+}
+
+build_xerces () {
+    echo "Building Xerces-C"
+    # TODO this works when OUTPUT_DIR is a relative path but fails if an absolute path
+    # TODO this does not work when the output dir is outside the current dir
+    mkdir -p xerces_patch/concourse
+    cp -r orca_src/concourse/xerces-c xerces_patch/concourse
+    cp -r orca_src/patches/ xerces_patch
+    /usr/bin/python xerces_patch/concourse/xerces-c/build_xerces.py --output_dir="/usr/local"
+    rm -rf build
+}
+
+build_orca () {
+    echo "Building orca"
+    orca_src/concourse/build_and_test.py --build_type=RelWithDebInfo --output_dir="/usr/local" --skiptests
+    # FIXME: build_and_test.py prepends `..` to the output_dir so we have to copy in to /usr/local
+    # ourselves
+    cp -a usr/local/* /usr/local
+    rm -rf usr build
+    # RHEL does not include `/usr/local/lib` in the default search path
+    echo "/usr/local/lib" >> /etc/ld.so.conf.d/gpdb.conf
+    ldconfig
+}
+
+install_python () {
+    echo "Installing python"
+    tar xzf python-tarball/python-*.tar.gz -C /opt --strip-components=2
+    export PATH="/opt/python-2.7.12/bin:${PATH}"
+    export PYTHONHOME=/opt/python-2.7.12
+    echo "/opt/python-2.7.12/lib" >> /etc/ld.so.conf.d/gpdb.conf
+    ldconfig
+}
+
+generate_build_number() {
+  pushd gpdb_src
+    #Only if its git repro, add commit SHA as build number
+    # BUILD_NUMBER file is used by getversion file in GPDB to append to version
+    if [ -d .git ] ; then
+      echo "commit:$(git rev-parse HEAD)" > BUILD_NUMBER
+    fi
+  popd
+}
+
+build_gpdb () {
+    local greenplum_install_dir="${1}"
+
+    pushd gpdb_src
+        CC="gcc" CFLAGS="-O3 -fargument-noalias-global -fno-omit-frame-pointer -g" \
+            ./configure \
+                --enable-orca \
+                --with-zstd \
+                --with-gssapi \
+                --with-libxml \
+                --with-perl \
+                --with-python \
+                --with-openssl \
+                --with-pam \
+                --with-ldap \
+                --prefix="${greenplum_install_dir}" \
+                --mandir="${greenplum_install_dir}/man"
+        make -j
+        make install
+    popd
+
+
+    mkdir -p "${greenplum_install_dir}/etc"
+    mkdir -p "${greenplum_install_dir}/include"
+}
+
+include_xerces () {
+    local greenplum_install_dir="${1}"
+
+    echo "Including libxerces-c in greenplum package"
+    cp --archive /usr/local/lib/libxerces-c*.so "${greenplum_install_dir}/lib"
+}
+
+include_gporca () {
+    local greenplum_install_dir="${1}"
+
+    echo "Including libgpopt in greenplum package"
+    cp --archive /usr/local/lib/libgpopt.so.* "${greenplum_install_dir}/lib"
+}
+
+include_python () {
+    local greenplum_install_dir="${1}"
+
+    # Create the python directory to flag to build scripts that python has been handled
+    mkdir -p "${greenplum_install_dir}/ext/python"
+    echo "Copying python from /opt/python-2.7.12 into ${greenplum_install_dir}/ext/python..."
+    cp --archive /opt/python-2.7.12/* "${greenplum_install_dir}/ext/python"
+}
+
+include_libstdcxx () {
+    local greenplum_install_dir="${1}"
+
+    # if this is a platform that we use a non-system toolchain for, we need to
+    # vendor libstdc++
+    if [ -d /opt/gcc-6.4.0 ]; then
+        cp --archive /opt/gcc-6.4.0/lib64/libstdc++.so.6{,.0.22} "${greenplum_install_dir}/lib"
+    fi
+}
+
+include_zstd () {
+    local greenplum_install_dir="${1}"
+    local platform
+    platform="$(python -mplatform)"
+
+    local libdir
+    case "${platform}" in
+    *centos*) libdir=/usr/lib64 ;;
+    *Ubuntu*) libdir=/usr/lib ;;
+    *) return ;;
+    esac
+
+    cp --archive ${libdir}/libzstd.so.1* "${greenplum_install_dir}/lib"
+}
+
+export_gpdb () {
+    local greenplum_install_dir="${1}"
+    local tarball="${2}"
+
+    pushd "${greenplum_install_dir}"
+      (source greenplum_path.sh; python -m compileall -q -x test .)
+      tar -czf "${tarball}" ./*
+    popd
+}
+
+_main () {
+    fetch_orca_src "${ORCA_TAG}"
+
+    if [ -e /opt/gcc_env.sh ]; then
+        . /opt/gcc_env.sh
+    fi
+
+    build_xerces
+    build_orca
+
+    install_python
+
+    generate_build_number
+
+    local greenplum_install_dir="/usr/local/greenplum-db-oss"
+    build_gpdb "${greenplum_install_dir}"
+
+    include_xerces "${greenplum_install_dir}"
+    include_gporca "${greenplum_install_dir}"
+    include_python "${greenplum_install_dir}"
+    include_libstdcxx "${greenplum_install_dir}"
+    include_zstd "${greenplum_install_dir}"
+    export_gpdb "${greenplum_install_dir}" "${PWD}/gpdb_artifacts/bin_gpdb.tar.gz"
+
+}
+
+_main "${@}"

--- a/concourse/scripts/gpdb_github_release.bash
+++ b/concourse/scripts/gpdb_github_release.bash
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+apk update && apk add --no-progress git
+
+BASE_DIR="$(pwd)"
+
+GPDB_RELEASE_COMMIT_SHA="$(cat gpdb_src/.git/ref)"
+GPDB_RELEASE_TAG="$(git --git-dir gpdb_src/.git describe --tags ${GPDB_RELEASE_COMMIT_SHA})"
+
+function build_gpdb_binaries_tarball(){
+    pushd "${BASE_DIR}/gpdb_src"
+        git --no-pager show --summary refs/tags/"${GPDB_RELEASE_TAG}"
+
+        # TODO: adding the gpdb_bin_${PLATFORM} tar.gz here
+        # The tar.gz and .zip files are the github release attachements.
+        # here, I just want to test the uploading attachments function for github release concourse resource.
+        # later, we can upload the binaries of gpdb instead of them.
+        # eg. bin_gpdb_centos6.tar.gz, bin_gpdb_unbuntu18.04.tar.gz ...
+
+        git archive -o "${BASE_DIR}/release_artifacts/${GPDB_RELEASE_TAG}.tar.gz" --prefix="gpdb-${GPDB_RELEASE_TAG}/"  --format=tar.gz  refs/tags/"${GPDB_RELEASE_TAG}"
+        git archive -o "${BASE_DIR}/release_artifacts/${GPDB_RELEASE_TAG}.zip" --prefix="gpdb-${GPDB_RELEASE_TAG}/" --format=zip  -9 refs/tags/"${GPDB_RELEASE_TAG}"
+    popd
+    echo "Created the release binaries successfully! [tar.gz, zip]"
+}
+
+function create_github_release_metadata(){
+    # Prepare for the gpdb github release
+    echo "${GPDB_RELEASE_TAG}" > "release_artifacts/name"
+    echo "${GPDB_RELEASE_TAG}" > "release_artifacts/tag"
+    echo "Greenplum-db version: ${GPDB_RELEASE_TAG}" > "release_artifacts/body"
+    echo "${GPDB_RELEASE_COMMIT_SHA}" > release_artifacts/commitish
+}
+
+function _main(){
+    echo "Current Released Tag: ${GPDB_RELEASE_TAG}"
+
+    build_gpdb_binaries_tarball
+    create_github_release_metadata
+}
+
+_main
+

--- a/concourse/tasks/build_gpdb_debian.yml
+++ b/concourse/tasks/build_gpdb_debian.yml
@@ -1,0 +1,29 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+
+inputs:
+  - name: bin_gpdb
+  - name: gpdb_src
+  - name: greenplum-database-release_src
+
+outputs:
+  - name: gpdb_debian_installer
+
+run:
+  path: greenplum-database-release_src/concourse/scripts/build_gpdb_debian.bash
+
+params:
+  PLATFORM:
+  # Default values passed to debian package
+  #  To override, please do so in pipeline
+  GPDB_NAME: greenplum-db
+  GPDB_SUMMARY: Greenplum-DB
+  GPDB_LICENSE: Pivotal Software EULA
+  GPDB_URL: https://network.pivotal.io/products/pivotal-gpdb/
+  GPDB_BUILDARCH: amd64
+  GPDB_DESCRIPTION: Pivotal Greenplum Server
+  GPDB_PREFIX: /usr/local

--- a/concourse/tasks/build_gpdb_debian.yml
+++ b/concourse/tasks/build_gpdb_debian.yml
@@ -9,6 +9,7 @@ inputs:
   - name: bin_gpdb
   - name: gpdb_src
   - name: greenplum-database-release_src
+  - name: license_file
 
 outputs:
   - name: gpdb_debian_installer
@@ -22,7 +23,6 @@ params:
   #  To override, please do so in pipeline
   GPDB_NAME: greenplum-db
   GPDB_SUMMARY: Greenplum-DB
-  GPDB_LICENSE: Pivotal Software EULA
   GPDB_URL: https://network.pivotal.io/products/pivotal-gpdb/
   GPDB_BUILDARCH: amd64
   GPDB_DESCRIPTION: Pivotal Greenplum Server

--- a/concourse/tasks/compile_gpdb_oss.yml
+++ b/concourse/tasks/compile_gpdb_oss.yml
@@ -1,0 +1,13 @@
+platform: linux
+image_resource:
+  type: docker-image
+inputs:
+  - name: gpdb_src
+  - name: python-tarball
+  - name: greenplum-database-release_src
+outputs:
+  - name: gpdb_artifacts
+run:
+  path: greenplum-database-release_src/concourse/scripts/compile_gpdb_oss.bash
+params:
+  ORCA_TAG: v3.51.0

--- a/concourse/tasks/gpdb_github_release.yml
+++ b/concourse/tasks/gpdb_github_release.yml
@@ -1,0 +1,19 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bash
+    tag: latest
+
+inputs:
+  - name: gpdb_src
+  - name: greenplum-database-release_src
+
+outputs:
+  - name: release_artifacts
+
+run:
+  path: greenplum-database-release_src/concourse/scripts/gpdb_github_release.bash


### PR DESCRIPTION
It consist following pr and commit from previous work with @bradfordboyle 
https://github.com/greenplum-db/gpdb/pull/7906 all ready merged
https://github.com/greenplum-db/gpdb/pull/7976 not merged
https://github.com/BaiShaoqi/gpdb/commit/ccc43d03728f175d2fb71129c7210e1d4679e590 not merged

It's related to tracker 
https://www.pivotaltracker.com/story/show/166344814
https://www.pivotaltracker.com/story/show/166369681
https://www.pivotaltracker.com/story/show/166344846

dev pipeline: https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release-new_repo-sbai

TODO, https://github.com/pivotal/gp-continuous-integration#gpdb-oss-release is not needed, because in this repo, can use make set-dev to do the same thing.

TODO,  the yml file `concourse/pipelines/gpdb_opensource_release.yml `, `concourse/scripts/compile_gpdb_oss.bash`, `concourse/tasks/compile_gpdb_oss.yml ` in  https://github.com/greenplum-db/gpdb/pull/7906  should be deleted, because they are moved in this new repo

TODO, the https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-oss-release should be deleted, and a new prod pipeline should be created by make prod