### PR TITLE
Fix set-pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,10 @@ list:
 set-dev: set-pipeline-dev
 
 set-pipeline-dev:
-
-	sed -e 's|tag_filter: *|## tag_filter: |g' concourse/pipelines/gpdb_opensource_release.yml > concourse/pipelines/${PIPELINE_NAME}.yml
-
 	$(FLY_CMD) --target=${CONCOURSE} \
     set-pipeline \
     --pipeline=${PIPELINE_NAME} \
-    --config=concourse/pipelines/${PIPELINE_NAME}.yml \
+    --config=concourse/pipelines/gpdb_opensource_release.yml \
     --load-vars-from=${HOME}/workspace/gp-continuous-integration/secrets/gpdb-oss-release.dev.yml  \
     --var=greenplum-database-release-git-branch=${BRANCH} \
     --var=greenplum-database-release-git-remote=https://github.com/greenplum-db/greenplum-database-release.git \
@@ -85,4 +82,4 @@ set-pipeline-prod:
     ${FLY_OPTION_NON-INTERACTIVE}
 
 	@echo using the following command to unpause the pipeline:
-	@echo "\t$(FLY_CMD) -t prod unpause-pipeline --pipeline 6X-release"
+	@echo "\t$(FLY_CMD) -t prod unpause-pipeline --pipeline greenplum-database-release"

--- a/concourse/tasks/compile_gpdb_oss.yml
+++ b/concourse/tasks/compile_gpdb_oss.yml
@@ -10,4 +10,4 @@ outputs:
 run:
   path: greenplum-database-release_src/concourse/scripts/compile_gpdb_oss.bash
 params:
-  ORCA_TAG: v3.51.0
+  ORCA_TAG: v3.50.0


### PR DESCRIPTION
For greenplum-database-release  dev pipeline , using 6X stable branch and not comment tag_filter should be more reasonal.
Also to align orca with 6X stable 6.0.0-beta.4, orca should be downgrade to v3.50.0