### PR TITLE
Fix set-pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ set-pipeline-prod:
     ${FLY_OPTION_NON-INTERACTIVE}
 
 	@echo using the following command to unpause the pipeline:
-	@echo "\t$(FLY_CMD) -t prod unpause-pipeline --pipeline 6X-release"
+	@echo "\t$(FLY_CMD) -t prod unpause-pipeline --pipeline greenplum-database-release"

--- a/concourse/scripts/compile_gpdb_oss.bash
+++ b/concourse/scripts/compile_gpdb_oss.bash
@@ -145,6 +145,7 @@ export_gpdb () {
 }
 
 _main () {
+    export ORCA_TAG="$(grep 'ORCA_TAG:' gpdb_src/concourse/tasks/compile_gpdb.yml | cut -d ':' -f 2 | tr -d '[:space:]')"
     fetch_orca_src "${ORCA_TAG}"
 
     if [ -e /opt/gcc_env.sh ]; then

--- a/concourse/tasks/compile_gpdb_oss.yml
+++ b/concourse/tasks/compile_gpdb_oss.yml
@@ -25,6 +25,3 @@ outputs:
 
 run:
   path: greenplum-database-release_src/concourse/scripts/compile_gpdb_oss.bash
-
-params:
-  ORCA_TAG: v3.51.0


### PR DESCRIPTION
Now the ORCA_TAG can be automatically extracted from gpdb src.
make set-dev do not comment out the tag_filter
Use right pipeline name to fly -t prod unpause-pipeline

Dev pipeline: https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release-fix-make-sbai