### PR TITLE
Update closed repos to use `greenplum-database-release` for deb packaging

### DIFF
--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -43,7 +43,7 @@ resources:
       uri: ((gpdb-git-remote))
       tag_filter: ((gpdb-git-tag-filter))
 
-  - name: greenplum-database-release_src
+  - name: greenplum-database-release
     type: git
     source:
       branch: ((greenplum-database-release-git-branch))
@@ -143,12 +143,12 @@ jobs:
       - aggregate:
           - get: gpdb_src
             trigger: true
-          - get: greenplum-database-release_src
+          - get: greenplum-database-release
           - get: gpdb6-centos6-build
           - get: python-tarball
             resource: python-centos6
       - task: compile_gpdb
-        file: greenplum-database-release_src/concourse/tasks/compile_gpdb_oss.yml
+        file: greenplum-database-release/concourse/tasks/compile_gpdb_oss.yml
         image: gpdb6-centos6-build
       - put: bin_gpdb_centos6
         params:
@@ -159,13 +159,13 @@ jobs:
       - aggregate:
           - get: gpdb_src
             trigger: true
-          - get: greenplum-database-release_src
+          - get: greenplum-database-release
           - get: gpdb6-centos7-build
           - get: python-tarball
             resource: python-centos7
       - task: compile_gpdb
         image: gpdb6-centos7-build
-        file: greenplum-database-release_src/concourse/tasks/compile_gpdb_oss.yml
+        file: greenplum-database-release/concourse/tasks/compile_gpdb_oss.yml
       - put: bin_gpdb_centos7
         params:
           file: gpdb_artifacts/bin_gpdb.tar.gz
@@ -175,13 +175,13 @@ jobs:
       - aggregate:
           - get: gpdb_src
             trigger: true
-          - get: greenplum-database-release_src
+          - get: greenplum-database-release
           - get: gpdb6-ubuntu18.04-build
           - get: python-tarball
             resource: python-ubuntu18.04
       - task: compile_gpdb
         image: gpdb6-ubuntu18.04-build
-        file: greenplum-database-release_src/concourse/tasks/compile_gpdb_oss.yml
+        file: greenplum-database-release/concourse/tasks/compile_gpdb_oss.yml
       - put:  bin_gpdb_ubuntu18.04
         params:
           file: gpdb_artifacts/bin_gpdb.tar.gz
@@ -232,7 +232,7 @@ jobs:
           - get: gpdb_src
             trigger: true
             passed: [compile_gpdb_ubuntu18.04]
-          - get: greenplum-database-release_src
+          - get: greenplum-database-release
             passed: [compile_gpdb_ubuntu18.04]
           - get: bin_gpdb_ubuntu18.04
             passed: [compile_gpdb_ubuntu18.04]
@@ -246,7 +246,7 @@ jobs:
         output_mapping:
           rc_bin_gpdb: rc_bin_gpdb_ubuntu18.04
       - task: create_gpdb_deb_package
-        file: greenplum-database-release_src/concourse/tasks/build_gpdb_deb.yml
+        file: greenplum-database-release/concourse/tasks/build_gpdb_deb.yml
         image: gpdb6-ubuntu18.04-build
         input_mapping:
           bin_gpdb: rc_bin_gpdb_ubuntu18.04
@@ -325,9 +325,9 @@ jobs:
           - get: license_file
           - get: gpdb_deb_package
             passed: [release]
-          - get: greenplum-database-release_src
+          - get: greenplum-database-release
       - task: gpdb_github_release
-        file: greenplum-database-release_src/concourse/tasks/gpdb_github_release.yml
+        file: greenplum-database-release/concourse/tasks/gpdb_github_release.yml
       - put: gpdb_release
         params:
           name: release_artifacts/name

--- a/concourse/scripts/build_gpdb_deb.bash
+++ b/concourse/scripts/build_gpdb_deb.bash
@@ -40,7 +40,9 @@ exit 0
 EOF
 	chmod 0775 "${__package_name}/DEBIAN/postrm"
 	mkdir -p "${__package_name}/usr/share/doc/greenplum-db/"
-	cp ../license_file/*.txt "${__package_name}/usr/share/doc/greenplum-db/copyright"
+	if [ -d ../license_file ]; then
+	    cp ../license_file/*.txt "${__package_name}/usr/share/doc/greenplum-db/copyright"
+	fi
 
 	cat <<EOF >"${__package_name}/DEBIAN/control"
 Package: greenplum-db

--- a/concourse/tasks/build_gpdb_deb.yml
+++ b/concourse/tasks/build_gpdb_deb.yml
@@ -18,14 +18,16 @@ image_resource:
 inputs:
   - name: bin_gpdb
   - name: gpdb_src
-  - name: greenplum-database-release_src
+    optional: true
+  - name: greenplum-database-release
   - name: license_file
+    optional: true
 
 outputs:
   - name: gpdb_deb_installer
 
 run:
-  path: greenplum-database-release_src/concourse/scripts/build_gpdb_deb.bash
+  path: greenplum-database-release/concourse/scripts/build_gpdb_deb.bash
 
 params:
   PLATFORM:

--- a/concourse/tasks/compile_gpdb_oss.yml
+++ b/concourse/tasks/compile_gpdb_oss.yml
@@ -18,10 +18,10 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: python-tarball
-  - name: greenplum-database-release_src
+  - name: greenplum-database-release
 
 outputs:
   - name: gpdb_artifacts
 
 run:
-  path: greenplum-database-release_src/concourse/scripts/compile_gpdb_oss.bash
+  path: greenplum-database-release/concourse/scripts/compile_gpdb_oss.bash

--- a/concourse/tasks/gpdb_github_release.yml
+++ b/concourse/tasks/gpdb_github_release.yml
@@ -20,10 +20,10 @@ image_resource:
 
 inputs:
   - name: gpdb_src
-  - name: greenplum-database-release_src
+  - name: greenplum-database-release
 
 outputs:
   - name: release_artifacts
 
 run:
-  path: greenplum-database-release_src/concourse/scripts/gpdb_github_release.bash
+  path: greenplum-database-release/concourse/scripts/gpdb_github_release.bash


### PR DESCRIPTION
To make build_gpdb_debian.yml build_gpdb_debian.bash also works for
closed repos, the license_file input should be
made optional, because it now only need in open source debian build.
Also make gpdb_src optional, because other repos do not use
gpdb_src to extract the actual version, but use a fake GPDB_VERSION:
"1.0.0"

Dev pipeline: https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release-rm-dup-deb-sbai