### PR TITLE
Include missing gporca libraries

### DIFF
--- a/concourse/scripts/compile_gpdb_oss.bash
+++ b/concourse/scripts/compile_gpdb_oss.bash
@@ -99,7 +99,10 @@ include_gporca () {
     local greenplum_install_dir="${1}"
 
     echo "Including libgpopt in greenplum package"
+    cp --archive /usr/local/lib/libgpdbcost.so.* "${greenplum_install_dir}/lib"
     cp --archive /usr/local/lib/libgpopt.so.* "${greenplum_install_dir}/lib"
+    cp --archive /usr/local/lib/libgpos.so.* "${greenplum_install_dir}/lib"
+    cp --archive /usr/local/lib/libnaucrates.so.* "${greenplum_install_dir}/lib"
 }
 
 include_python () {


### PR DESCRIPTION
gporca builds multiple shared-objects that need to be included in the
greenplum-database binary distribution. This commit adds the missing
libraries.

Authored-by: Bradford D. Boyle <bboyle@pivotal.io>