### PR TITLE
OSL attribution file of Open Source Greenplum 6 Database Server in the RPM Installers

### DIFF
--- a/concourse/scripts/build_gpdb_rpm.bash
+++ b/concourse/scripts/build_gpdb_rpm.bash
@@ -35,8 +35,20 @@ function determine_rpm_build_dir() {
 function setup_rpm_buildroot() {
   local __rpm_build_dir="${1}"
   local __gpdb_binary_tarbal="${2}"
+  local __bin_gpdb
 
   mkdir -p "${__rpm_build_dir}"/{SOURCES,SPECS}
+  # GPDB_NAME="greenplum-database" indicates open source gpdb and it requires license_file exist.
+  if [ "${GPDB_NAME}" == "greenplum-database" ]; then
+    if [ ! -d license_file ]; then
+      die "Not provide license_file when build open source gpdb rpm"
+    fi
+    gunzip "${__gpdb_binary_tarbal}"
+    cp license_file/*.txt copyright
+    __bin_gpdb=$(dirname "${__gpdb_binary_tarbal}")
+    tar rf "${__bin_gpdb}"/*.tar copyright
+    gzip "${__bin_gpdb}"/*.tar
+  fi
   cp "${__gpdb_binary_tarbal}" "${__rpm_build_dir}/SOURCES/gpdb.tar.gz"
 }
 
@@ -109,7 +121,7 @@ function _main() {
   echo "[INFO] GPDB version modified for rpm requirements: ${__rpm_gpdb_version}"
 
   # Build the expected rpm name based on the gpdb version of the artifacts
-  __final_rpm_name="greenplum-db-${__gpdb_version}-${PLATFORM}-x86_64.rpm"
+  __final_rpm_name="${GPDB_NAME}-${__gpdb_version}-${PLATFORM}-x86_64.rpm"
   echo "[INFO] Final RPM name: ${__final_rpm_name}"
 
   # Conventional location to build RPMs is platform specific

--- a/concourse/scripts/greenplum-db.spec
+++ b/concourse/scripts/greenplum-db.spec
@@ -75,6 +75,12 @@ cp -R * %{buildroot}%{bin_gpdb}
 exit 0
 
 %files
+# only Open Source Greenplum provide copyright, and the difference is the gpdb_name
+# for open source greenplum it is greenplum-database, while non open source greenplum is greenplum-db
+%if "%{gpdb_name}" == "greenplum-database"
+%doc copyright
+%{bin_gpdb}/copyright
+%endif
 %{bin_gpdb}
 
 %clean

--- a/concourse/tasks/build_gpdb_rpm.yml
+++ b/concourse/tasks/build_gpdb_rpm.yml
@@ -10,6 +10,8 @@ inputs:
   - name: greenplum-database-release
   - name: gpdb_src
     optional: true
+  - name: license_file
+    optional: true
 
 outputs:
   - name: gpdb_rpm_installer


### PR DESCRIPTION
dev: https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release-doc-sbai
now, after `rpm -i greenplum-db-6.0.0-beta.4-rhel6-x86_64.rpm` the doc will be showing in `/usr/share/doc/greenplum-database-6.0.0_beta.4/copyright` and also `/usr/local/greenplum-database/copyright`