### PR TITLE
Use open_source_license_greenplum_database.txt as the name

### DIFF
--- a/concourse/scripts/build_gpdb_rpm.bash
+++ b/concourse/scripts/build_gpdb_rpm.bash
@@ -54,10 +54,11 @@ function setup_rpm_buildroot() {
     if [ ! -d license_file ]; then
       die "Not provide license_file when build open source gpdb rpm"
     fi
+    # append license_file/*.txt to bin_gpdb/*.tar
     gunzip "${__gpdb_binary_tarbal}"
-    cp license_file/*.txt copyright
+    cp license_file/*.txt open_source_license_greenplum_database.txt
     __bin_gpdb=$(dirname "${__gpdb_binary_tarbal}")
-    tar rf "${__bin_gpdb}"/*.tar copyright
+    tar rf "${__bin_gpdb}"/*.tar open_source_license_greenplum_database.txt
     gzip "${__bin_gpdb}"/*.tar
   fi
   cp "${__gpdb_binary_tarbal}" "${__rpm_build_dir}/SOURCES/gpdb.tar.gz"

--- a/concourse/scripts/greenplum-db.spec
+++ b/concourse/scripts/greenplum-db.spec
@@ -89,8 +89,7 @@ exit 0
 # only Open Source Greenplum provide copyright, and the difference is the gpdb_name
 # for open source greenplum it is greenplum-database, while non open source greenplum is greenplum-db
 %if "%{gpdb_name}" == "greenplum-database"
-%doc copyright
-%{bin_gpdb}/copyright
+%doc open_source_license_greenplum_database.txt
 %endif
 %{bin_gpdb}
 


### PR DESCRIPTION
the file content's is not look like COPYRIGHT, so use
open_source_license_greenplum_database.txt as the suggested name

Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>
Co-authored-by: Kris Macoskey <kmacoskey@pivotal.io>
Co-authored-by: Shaoqi Bai <sbai@pivotal.io>