### PR TITLE
Change the package name to greenplum-db

### DIFF
--- a/concourse/oss/rpmbuild.py
+++ b/concourse/oss/rpmbuild.py
@@ -42,7 +42,7 @@ class RPMPackageBuilder(BasePackageBuilder):
         self._pre_check()
 
     def _pre_check(self):
-        if self.name == "greenplum-database" and not os.path.exists(self.license_file_path):
+        if self.name == "greenplum-db" and not os.path.exists(self.license_file_path):
             raise Exception("Build the OpenSource GPDB need the license file!")
 
     def build(self):
@@ -82,7 +82,7 @@ class RPMPackageBuilder(BasePackageBuilder):
         for sub_dir in ["SOURCES", "SPECS"]:
             os.makedirs(os.path.join(self.rpm_build_dir, sub_dir), mode=0o755)
 
-        if self.name == "greenplum-database" and os.path.exists(self.license_file_path):
+        if self.name == "greenplum-db" and os.path.exists(self.license_file_path):
             temp_dir = tempfile.mkdtemp()
             print("TEMP DIR: %s" % temp_dir)
 

--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -219,7 +219,7 @@ jobs:
       bin_gpdb: bin_gpdb_centos6
     params:
       PLATFORM: "rhel6"
-      GPDB_NAME: greenplum-database
+      GPDB_NAME: greenplum-db
       GPDB_RELEASE: 1
       GPDB_SUMMARY: Greenplum-DB
       GPDB_LICENSE: Pivotal Software EULA
@@ -250,7 +250,7 @@ jobs:
       bin_gpdb: bin_gpdb_centos7
     params:
       PLATFORM: "rhel7"
-      GPDB_NAME: greenplum-database
+      GPDB_NAME: greenplum-db
       GPDB_RELEASE: 1
       GPDB_SUMMARY: Greenplum-DB
       GPDB_LICENSE: Pivotal Software EULA

--- a/concourse/scripts/greenplum-db.spec
+++ b/concourse/scripts/greenplum-db.spec
@@ -87,8 +87,8 @@ exit 0
 
 %files
 # only Open Source Greenplum provide copyright, and the difference is the gpdb_name
-# for open source greenplum it is greenplum-database, while non open source greenplum is greenplum-db
-%if "%{gpdb_name}" == "greenplum-database"
+# for open source greenplum it is greenplum-db, while non open source greenplum is greenplum-db
+%if "%{gpdb_name}" == "greenplum-db"
 %doc open_source_license_greenplum_database.txt
 %endif
 %{bin_gpdb}

--- a/concourse/tasks/build_gpdb_rpm.py
+++ b/concourse/tasks/build_gpdb_rpm.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     license_file_path = ""
 
     gpdb_name = os.environ["GPDB_NAME"]
-    if gpdb_name == "greenplum-database":
+    if gpdb_name == "greenplum-db":
         license_file_path = os.path.abspath(glob.glob("license_file/*.txt")[0])
 
     rpm_builder = RPMPackageBuilder(

--- a/concourse/tasks/publish_to_ppa.py
+++ b/concourse/tasks/publish_to_ppa.py
@@ -18,7 +18,7 @@ from oss.ppa import SourcePackageBuilder, DebianPackageBuilder, LaunchpadPublish
 if __name__ == '__main__':
     source_package = SourcePackageBuilder(
         bin_gpdb_path='bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz',
-        package_name='greenplum-database',
+        package_name='greenplum-db',
         release_message=os.environ["RELEASE_MESSAGE"]
     ).build()
 

--- a/concourse/tests/build_gpdb_rpm_test.py
+++ b/concourse/tests/build_gpdb_rpm_test.py
@@ -22,7 +22,7 @@ class TestRPMPackageBuilder(TestCase):
     def setUp(self):
         os.system("rm -rf /tmp/lic.txt; echo 'license content' > /tmp/lic.txt")
         self.rpm_package_builder = RPMPackageBuilder(
-            name="greenplum-database",
+            name="greenplum-db",
             release="1",
             platform="rhel6",
             summary="Greenplum-DB",
@@ -45,7 +45,7 @@ class TestRPMPackageBuilder(TestCase):
         with self.assertRaisesRegex(Exception, 'The platform only support rhel6, rhel7'):
             self.rpm_package_builder.platform = "ubuntu18.04"
         self.assertEqual(self.rpm_package_builder.rpm_package_name,
-                         "greenplum-database-gpdb-6.0.0-beta.5+dev.18.g6a02f28-rhel6-x86_64.rpm")
+                         "greenplum-db-gpdb-6.0.0-beta.5+dev.18.g6a02f28-rhel6-x86_64.rpm")
 
     @patch('oss.base.BasePackageBuilder.gpdb_version_short', new_callable=PropertyMock)
     @patch('oss.rpmbuild.RPMPackageBuilder._prepare_rpm_build_dir')
@@ -60,7 +60,7 @@ class TestRPMPackageBuilder(TestCase):
                    '--define="rpm_gpdb_version gpdb_6.0.0_beta.5+dev.18.g6a02f28" '
                    '--define="gpdb_version gpdb-6.0.0-beta.5+dev.18.g6a02f28" '
                    '--define="gpdb_release 1" '
-                   '--define="gpdb_name greenplum-database" '
+                   '--define="gpdb_name greenplum-db" '
                    '--define="gpdb_summary Greenplum-DB" '
                    '--define="gpdb_license Pivotal Software EULA" '
                    '--define="gpdb_url https://github.com/greenplum-db/gpdb" '


### PR DESCRIPTION
Historically, Greenplum has been installed into a directory named
"greenplum-db" and we would like to maintain this convention. In order
to reduce confusion, we are changing the package name to match with the
installation prefix.

Co-authored-by: Bradford D. Boyle <bboyle@pivotal.io>
Co-authored-by: Shaoqi Bai <sbai@pivotal.io>