### PR TITLE
Add the LICENSE and COPYRIGHT file to installer for OSS gpdb

### DIFF
--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -291,10 +291,13 @@ jobs:
 - name: publish to ppa
   plan:
   - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_ubuntu18.04]
     - get: greenplum-database-release
       passed: [compile_gpdb_ubuntu18.04]
     - get: bin_gpdb_ubuntu18.04
       passed: [compile_gpdb_ubuntu18.04]
+    - get: license_file
   - task: push to ppa
     file: greenplum-database-release/concourse/tasks/publish_to_ppa.yml
     params:

--- a/concourse/pipelines/gpdb_opensource_release.yml
+++ b/concourse/pipelines/gpdb_opensource_release.yml
@@ -283,6 +283,7 @@ jobs:
       bin_gpdb: bin_gpdb_ubuntu18.04
     params:
       PLATFORM: "ubuntu18.04"
+      GPDB_OSS: true
   - put: gpdb_deb_package
     params:
       file: gpdb_deb_installer/*.deb

--- a/concourse/scripts/build_gpdb_deb.bash
+++ b/concourse/scripts/build_gpdb_deb.bash
@@ -57,6 +57,29 @@ EOF
 	    cp ../license_file/*.txt "${__package_name}/usr/share/doc/greenplum-db/open_source_license_greenplum_database.txt"
 	fi
 
+	if [[ "${GPDB_OSS}" == 'true' ]];then
+		SHARE_DOC_ROOT="${__package_name}/usr/share/doc/greenplum-db"
+
+		cp ../gpdb_src/LICENSE "${SHARE_DOC_ROOT}/LICENSE"
+		cp ../gpdb_src/COPYRIGHT "${SHARE_DOC_ROOT}/COPYRIGHT"
+
+		cat <<NOTICE_EOF >"${SHARE_DOC_ROOT}/NOTICE"
+Greenplum Database
+
+Copyright (c) 2019 Pivotal Software, Inc. All Rights Reserved.
+
+This product is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use this product except in compliance with the License.
+
+This product may include a number of subcomponents with separate copyright notices
+and license terms. Your use of these subcomponents is subject to the terms and
+conditions of the subcomponent's license, as noted in the LICENSE file.
+NOTICE_EOF
+	else
+		echo "Pivotal EUAL file is here!"
+		# TODO: Pivotal EUAL file should be here!
+	fi
+
 	cat <<EOF >"${__package_name}/DEBIAN/control"
 Package: greenplum-db
 Priority: extra

--- a/concourse/tasks/build_gpdb_deb.yml
+++ b/concourse/tasks/build_gpdb_deb.yml
@@ -39,3 +39,5 @@ params:
   GPDB_BUILDARCH: amd64
   GPDB_DESCRIPTION: Pivotal Greenplum Server
   GPDB_PREFIX: /usr/local
+  # build the Open Source gpdb, set this variable to 'true'
+  GPDB_OSS:

--- a/concourse/tasks/build_gpdb_rpm.py
+++ b/concourse/tasks/build_gpdb_rpm.py
@@ -16,6 +16,7 @@ import glob
 import shutil
 
 from oss.rpmbuild import RPMPackageBuilder
+from oss.utils import PackageTester
 
 if __name__ == '__main__':
     gpdb_src_path = ""
@@ -47,7 +48,16 @@ if __name__ == '__main__':
 
     rpm_builder.build()
 
+    rpm_file_path = os.path.abspath(glob.glob("%s/RPMS/x86_64/*.rpm" % rpm_builder.rpm_build_dir)[0])
+
+    if os.getenv("GPDB_OSS").lower() == "true":
+        print("Verify RPM package...")
+        packager_tester = PackageTester(rpm_file_path)
+        packager_tester.test_package()
+        print("All check actions passed!")
+
     # Copy the RPM package to output resource
     print("Copy the RPM package to the output resource")
-    rpm_file_path = os.path.abspath(glob.glob("%s/RPMS/x86_64/*.rpm" % rpm_builder.rpm_build_dir)[0])
     shutil.copy(rpm_file_path, os.path.join("gpdb_rpm_installer", rpm_builder.rpm_package_name))
+
+    print("Build RPM package finished!")

--- a/concourse/tasks/build_gpdb_rpm.py
+++ b/concourse/tasks/build_gpdb_rpm.py
@@ -18,11 +18,15 @@ import shutil
 from oss.rpmbuild import RPMPackageBuilder
 
 if __name__ == '__main__':
-    license_file_path = ""
+    gpdb_src_path = ""
 
     gpdb_name = os.environ["GPDB_NAME"]
-    if os.path.exists("license_file"):
-        license_file_path = os.path.abspath(glob.glob("license_file/*.txt")[0])
+    license_file_path = os.path.abspath(glob.glob("license_file/*.txt")[0])
+
+    # gpdb_src is the optional concourse input resource name
+    # only the OSS gpdb need the gpdb_src, copying the LICENSE, COPYRIGHT files from there.
+    if os.path.exists("gpdb_src"):
+        gpdb_src_path = os.path.abspath("gpdb_src")
 
     rpm_builder = RPMPackageBuilder(
         name=gpdb_name,
@@ -37,7 +41,8 @@ if __name__ == '__main__':
         oss=os.getenv("GPDB_OSS", "false"),
         bin_gpdb_path="bin_gpdb/bin_gpdb.tar.gz",
         spec_file_path="greenplum-database-release/concourse/scripts/greenplum-db.spec",
-        license_file_path=license_file_path
+        license_file_path=license_file_path,
+        gpdb_src_path=gpdb_src_path
     )
 
     rpm_builder.build()

--- a/concourse/tasks/build_gpdb_rpm.yml
+++ b/concourse/tasks/build_gpdb_rpm.yml
@@ -18,9 +18,10 @@ image_resource:
 
 inputs:
   - name: bin_gpdb
+  - name: gpdb_src
+    optional: true
   - name: greenplum-database-release
   - name: license_file
-    optional: true
 
 outputs:
   - name: gpdb_rpm_installer

--- a/concourse/tasks/publish_to_ppa.py
+++ b/concourse/tasks/publish_to_ppa.py
@@ -19,7 +19,9 @@ if __name__ == '__main__':
     source_package = SourcePackageBuilder(
         bin_gpdb_path='bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz',
         package_name='greenplum-db',
-        release_message=os.environ["RELEASE_MESSAGE"]
+        release_message=os.environ["RELEASE_MESSAGE"],
+        gpdb_src_path="gpdb_src",
+        license_dir_path="license_file"
     ).build()
 
     builder = DebianPackageBuilder(source_package=source_package)

--- a/concourse/tasks/publish_to_ppa.py
+++ b/concourse/tasks/publish_to_ppa.py
@@ -11,9 +11,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
+import glob
 import os
 
 from oss.ppa import SourcePackageBuilder, DebianPackageBuilder, LaunchpadPublisher
+from oss.utils import PackageTester
 
 if __name__ == '__main__':
     source_package = SourcePackageBuilder(
@@ -27,6 +29,12 @@ if __name__ == '__main__':
     builder = DebianPackageBuilder(source_package=source_package)
     builder.build_binary()
     builder.build_source()
+
+    deb_file_path = os.path.abspath(glob.glob("./*.deb")[0])
+    print("Verify DEB package...")
+    packager_tester = PackageTester(deb_file_path)
+    packager_tester.test_package()
+    print("All check actions passed!")
 
     ppa_repo = os.environ["PPA_REPO"]
     publisher = LaunchpadPublisher(ppa_repo, source_package)

--- a/concourse/tasks/publish_to_ppa.yml
+++ b/concourse/tasks/publish_to_ppa.yml
@@ -20,7 +20,9 @@ image_resource:
 
 inputs:
   - name: bin_gpdb_ubuntu18.04
+  - name: gpdb_src
   - name: greenplum-database-release
+  - name: license_file
 
 run:
   path: bash

--- a/concourse/tests/build_gpdb_rpm_test.py
+++ b/concourse/tests/build_gpdb_rpm_test.py
@@ -21,6 +21,7 @@ from oss.rpmbuild import RPMPackageBuilder
 class TestRPMPackageBuilder(TestCase):
     def setUp(self):
         os.system("rm -rf /tmp/lic.txt; echo 'license content' > /tmp/lic.txt")
+        os.system("mkdir -p /tmp/gpdb_src")
         self.rpm_package_builder = RPMPackageBuilder(
             name="greenplum-db",
             release="1",
@@ -34,7 +35,8 @@ class TestRPMPackageBuilder(TestCase):
             oss="true",
             bin_gpdb_path="bin_gpdb/bin_gpdb.tar.gz",
             spec_file_path="greenplum-database-release/concourse/scripts/greenplum-db.spec",
-            license_file_path="/tmp/lic.txt"
+            license_file_path="/tmp/lic.txt",
+            gpdb_src_path="/tmp/gpdb_src"
         )
 
     @patch('oss.base.BasePackageBuilder.gpdb_version_short', new_callable=PropertyMock)

--- a/concourse/tests/ppa_test.py
+++ b/concourse/tests/ppa_test.py
@@ -65,7 +65,7 @@ class TestSourcePackage(TestCase):
 
 class TestSourcePackageBuilder(TestCase):
     def setUp(self):
-        self.source_package_builder = SourcePackageBuilder('path', 'name', 'message')
+        self.source_package_builder = SourcePackageBuilder('path', 'name', 'message', "gpdb_src", "license_file")
         self.source_package_builder._gpdb_version_short = 'short-version'
         self.temp_dir = tempfile.mkdtemp()
 
@@ -93,7 +93,7 @@ class TestSourcePackageBuilder(TestCase):
 
     def test_install_contains_correct_path(self):
         install = self.source_package_builder._install()
-        self.assertEqual(install, 'bin_gpdb/* /opt/name-short-version\n')
+        self.assertEqual(install, 'bin_gpdb/* /opt/name-short-version\ndoc_files/* /usr/share/doc/greenplum-db/\n')
 
     @patch('oss.utils.Util.run_or_fail')
     def test_generate_changelog_runs_dch_command(self, mocked_run_or_fail):
@@ -104,15 +104,15 @@ class TestSourcePackageBuilder(TestCase):
                   cwd='name-short-version'),
              call(['dch', '--release', 'ignored message'], cwd='name-short-version')])
 
+    @patch('oss.ppa.SourcePackageBuilder._generate_license_files')
     @patch('oss.ppa.SourcePackageBuilder.source_dir', new_callable=PropertyMock)
-    def test_create_debian_dir(self, mock_source_dir):
+    def test_create_debian_dir(self, mock_source_dir, mock_generate_license_files):
         mock_source_dir.return_value = self.temp_dir
 
         self.source_package_builder.create_debian_dir()
         debian_dir = os.path.join(self.temp_dir, 'debian')
         self.assertTrue(os.path.isdir(debian_dir))
         self.assertTrue(os.path.isfile(os.path.join(debian_dir, 'compat')))
-        self.assertTrue(os.path.isfile(os.path.join(debian_dir, 'copyright')))
         self.assertTrue(os.path.isfile(os.path.join(debian_dir, 'rules')))
         self.assertTrue(os.path.isfile(os.path.join(debian_dir, 'control')))
 


### PR DESCRIPTION
* Include the open-source OSLO license and EUAL files for Enterprise gpdb.
* Include the LICENSE, COPYRIGHT, NOTICE and OSLO license files for OSS gpdb

Dev pipelines:
https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release-add_lic_copyright_files-baotingfang
https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/dev-6X-RELEASE-add_osl_lic-baotingfang
https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/dev-gpdb6-integration-testing-add_osl_lic-baotingfang

Authored-by: Tingfang Bao <bbao@pivotal.io>