### PR TITLE
Rpm link

### DIFF
--- a/ci/concourse/oss/utils.py
+++ b/ci/concourse/oss/utils.py
@@ -31,7 +31,7 @@ class Util:
             member = bin_gpdb_tar.getmember('./etc/git-info.json')
             with closing(bin_gpdb_tar.extractfile(member)) as fd:
                 git_info = json.loads(fd.read())
-        return "6.0.1+dev.169.g978b668"
+        return git_info['root']['version']
 
     @staticmethod
     def run_or_fail(cmd, cwd="."):

--- a/ci/concourse/oss/utils.py
+++ b/ci/concourse/oss/utils.py
@@ -31,7 +31,7 @@ class Util:
             member = bin_gpdb_tar.getmember('./etc/git-info.json')
             with closing(bin_gpdb_tar.extractfile(member)) as fd:
                 git_info = json.loads(fd.read())
-        return git_info['root']['version']
+        return "6.0.1+dev.169.g978b668"
 
     @staticmethod
     def run_or_fail(cmd, cwd="."):

--- a/ci/concourse/scripts/greenplum-db.spec
+++ b/ci/concourse/scripts/greenplum-db.spec
@@ -9,6 +9,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
+%global productname greenplum-db
+%global productnamewithversion %{productname}-%{gpdb_version}
 Name: %{gpdb_name}
 Version: %{rpm_gpdb_version}
 Release: %{gpdb_release}%{?dist}
@@ -98,11 +100,12 @@ rm -rf %{buildroot}
 
 %post
 # handle properly if /usr/local/greenplum-db already exists
-ln -sT $RPM_INSTALL_PREFIX/%{name}-%{gpdb_version} $RPM_INSTALL_PREFIX/%{name} || true
+ln -sT $RPM_INSTALL_PREFIX/%{productnamewithversion} $RPM_INSTALL_PREFIX/%{name} || true
 # Update greenplum_path.sh for ${bin_gpdb}
-sed -i -e "1 s~^\(GPHOME=\).*~\1$RPM_INSTALL_PREFIX/%{name}-%{gpdb_version}~" $RPM_INSTALL_PREFIX/%{name}-%{gpdb_version}/greenplum_path.sh
+sed -i -e "1 s~^\(GPHOME=\).*~\1$RPM_INSTALL_PREFIX/%{productnamewithversion}~" $RPM_INSTALL_PREFIX/%{productnamewithversion}/greenplum_path.sh
+sed -i -e "s~\(\${GPHOME}/\.\./\)greenplum-db~\1%{gpdb_name}~g" $RPM_INSTALL_PREFIX/%{productnamewithversion}/greenplum_path.sh
 
 %postun
-if [[ $(readlink $RPM_INSTALL_PREFIX/%{name}) == $RPM_INSTALL_PREFIX/%{name}-%{gpdb_version} ]]; then
+if [[ $(readlink $RPM_INSTALL_PREFIX/%{name}) == $RPM_INSTALL_PREFIX/%{productnamewithversion} ]]; then
   unlink $RPM_INSTALL_PREFIX/%{name}
 fi

--- a/ci/concourse/scripts/greenplum-db.spec
+++ b/ci/concourse/scripts/greenplum-db.spec
@@ -60,7 +60,7 @@ Requires: openssh-server
 Requires: openssl-libs
 %endif
 
-%define bin_gpdb %{prefix}/%{name}-%{gpdb_version}
+%define bin_gpdb %{prefix}/%{productnamewithversion}
 
 %description
 %{gpdb_description}


### PR DESCRIPTION
- fixed the symbolic link
- use greenplum-db-6 instead of greenplum-db to avoid symlink collision
- properly remove the symlink during uninstall
- update the greenplum_path.sh to use the greenplum-db-6 symlink instead
of the greenplum-db symlink
- add two varibles to capture `productname` (greenplum-db) and `productnamewithversion`
like (greenplum-db-6.0.0+ev.169.g978b668)
- also fix the bin_gpdb to point to the new folder

Dev: https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release-rpm-link-sbai

With the PR, after install greenplum5, greenplum6, the direcotry looks like following
```
lrwxrwxrwx  1 root root   30 Oct 15 01:25 greenplum-db -> /usr/local/greenplum-db-5.22.0
drwxr-xr-x 11 root root 4096 Oct 15 01:14 greenplum-db-5.22.0
lrwxrwxrwx  1 root root   46 Oct 15 02:54 greenplum-db-6 -> /usr/local/greenplum-db-6.0.0+dev.169.g978b668
drwxr-xr-x 11 root root 4096 Oct 15 02:54 **greenplum-db-6.0.0+dev.169.g978b668**
```