### PR TITLE
[Alternative solution] Archive gpdb src with submodules 

### DIFF
--- a/ci/concourse/scripts/gpdb_github_release.bash
+++ b/ci/concourse/scripts/gpdb_github_release.bash
@@ -28,8 +28,12 @@ function build_gpdb_binaries_tarball() {
 	git clean -fdx
 	popd
 
-	tar --exclude '.git*' -czf "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-full.tar.gz" gpdb_src
-	zip -r -q "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-full.zip" gpdb_src -x '*.git*'
+	# Why we do not use the `git archive` command to archive the gpdb source code
+	# 1. `git archive` can not archive the submodules parts directly
+	# 2. we have one implementation using `git archive`, you can ref:
+	# https://github.com/greenplum-db/greenplum-database-release/commit/4e15c018f82f647129ac6e704d4fd0e9a66c353a
+	tar --exclude '.git*' -czf "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-src-full.tar.gz" gpdb_src
+	zip -r -q "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-src-full.zip" gpdb_src -x '*.git*'
 	echo "Created the release binaries successfully! [tar.gz, zip]"
 }
 

--- a/ci/concourse/scripts/gpdb_github_release.bash
+++ b/ci/concourse/scripts/gpdb_github_release.bash
@@ -28,8 +28,8 @@ function build_gpdb_binaries_tarball() {
 	git clean -fdx
 	popd
 
-	tar --exclude '.git*' --exclude '.travis.yml' -czf "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-full.tar.gz" gpdb_src
-	zip -r -q "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-full.zip" gpdb_src -x '*.git*' -x '*.travis.yml'
+	tar --exclude '.git*' -czf "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-full.tar.gz" gpdb_src
+	zip -r -q "${OUTPUT_DIR}/${GPDB_RELEASE_TAG}-full.zip" gpdb_src -x '*.git*'
 	echo "Created the release binaries successfully! [tar.gz, zip]"
 }
 


### PR DESCRIPTION
  Exclude the .git .travis.yml files, support tar.gz and zip format.

The second solution for archiving gpdb source code.

[#168285479]

Co-authored-by: Xin Zhang <xzhang@pivotal.io>
Co-authored-by: Tingfang Bao <bbao@pivotal.io>