### PR TITLE
Verify the PPA release result

### DIFF
--- a/ci/concourse/pipelines/gpdb_opensource_release.yml
+++ b/ci/concourse/pipelines/gpdb_opensource_release.yml
@@ -16,6 +16,11 @@ resource_types:
   source:
     repository: frodenas/gcs-resource
 
+- name: ppa
+  type: docker-image
+  source:
+    repository: seveas/concourse-ppa-resource
+
 resources:
 ## Image Resources
 - name: gpdb6-centos6-build
@@ -169,6 +174,21 @@ resources:
     bucket: ((gcs-bucket-for-oss))
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: greenplum-oss-server/released/gpdb6/greenplum-db-(.*)-ubuntu18.04-amd64.deb
+
+- name: ppa_release_version
+  type: gcs
+  icon: google
+  source:
+    json_key: ((concourse-gcs-resources-service-account-key))
+    bucket: ((gcs-bucket-intermediates-for-oss))
+    versioned_file: ((pipeline-name))/ppa_release_version/version.txt
+
+- name: greenplum_db_ppa
+  type: ppa
+  source:
+    ppa: ((ppa-login))
+    package: ((ppa-package-name))
+    api_token: ((ppa-api-token))
 
 jobs:
 - name: compile_gpdb_centos6
@@ -326,6 +346,22 @@ jobs:
       RELEASE_MESSAGE: ((release-message))
       DEBFULLNAME: ((debian-package-maintainer-fullname))
       DEBEMAIL: ((debian-package-maintainer-email))
+  - put: ppa_release_version
+    params:
+      file: ppa_release/version.txt
+
+- name: verify ppa release
+  plan:
+  - in_parallel:
+    - get: greenplum-database-release
+      passed: [publish to ppa]
+    - get: greenplum_db_ppa
+      trigger: true
+    - get: ppa_release_version
+      passed: [publish to ppa]
+      trigger: true
+  - task: verify ppa release status
+    file: greenplum-database-release/ci/concourse/tasks/verify_ppa_release.yml
 
 - name: release
   plan:
@@ -335,7 +371,7 @@ jobs:
       - rhel6 packaging
       - rhel7 packaging
       - ubuntu18.04 packaging
-      - publish to ppa
+      - verify ppa release
     - get: gpdb_src
       passed:
       - rhel6 packaging

--- a/ci/concourse/scripts/publish_to_ppa.py
+++ b/ci/concourse/scripts/publish_to_ppa.py
@@ -18,14 +18,19 @@ from oss.ppa import SourcePackageBuilder, DebianPackageBuilder, LaunchpadPublish
 from oss.utils import PackageTester
 
 if __name__ == '__main__':
-    source_package = SourcePackageBuilder(
+    package_builder = SourcePackageBuilder(
         bin_gpdb_path='bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz',
         package_name='greenplum-db',
         release_message=os.environ["RELEASE_MESSAGE"],
         gpdb_src_path="gpdb_src",
         license_dir_path="license_file"
-    ).build()
+    )
 
+    gpdb_ppa_version = f'{package_builder.gpdb_upstream_version}-{package_builder.debian_revision}'
+    with open("ppa_release/version.txt", "w") as f:
+        f.write(gpdb_ppa_version)
+
+    source_package = package_builder.build()
     builder = DebianPackageBuilder(source_package=source_package)
     builder.build_binary()
     builder.build_source()

--- a/ci/concourse/tasks/verify_ppa_release.yml
+++ b/ci/concourse/tasks/verify_ppa_release.yml
@@ -19,32 +19,30 @@ image_resource:
     tag: 18.04
 
 inputs:
-- name: bin_gpdb_ubuntu18.04
-- name: gpdb_src
-- name: greenplum-database-release
-- name: license_file
-
-outputs:
-- name: ppa_release
+- name: ppa_release_version
+- name: greenplum_db_ppa
 
 run:
   path: bash
   args:
   - -ec
   - |
-    cp greenplum-database-release/ci/concourse/scripts/dput.cf ~/.dput.cf
     apt-get update -q=2
-    apt-get install -q=2 -y software-properties-common debmake equivs git
-    gpg --import <(echo "${GPG_PRIVATE_KEY}")
+    apt-get install -q=2 -y jq
 
-    export PYTHONPATH=${PWD}/greenplum-database-release/ci/concourse
-    pushd greenplum-database-release/ci/concourse && python3 -m unittest tests/ppa_test.py && popd
-    python3 greenplum-database-release/ci/concourse/scripts/publish_to_ppa.py
+    version=$(jq -r .version.version greenplum_db_ppa/data.json)
+    target_version=$(cat ppa_release_version/version.txt)
 
-params:
-  PPA_REPO:
-  GPG_PRIVATE_KEY:
-  RELEASE_MESSAGE:
-  # The DEBFULLNAME and DEBMAIL environment variables are expected in the .deb building process
-  DEBFULLNAME:
-  DEBEMAIL:
+    if [ "${version}" != "${target_version}" ]; then
+            cat <<EOF
+        "${version}" != "${target_version}"
+        The latest greeenplum-db version on PPA does not match current release version!
+        This may be temporary due to delay release on PPA, Waiting a few miniutes and
+        manually re-triggering is suggested.
+    EOF
+            exit 1
+        else
+            cat <<EOF
+        Verified the release status successfully!
+    EOF
+    fi


### PR DESCRIPTION

This PR is a bug fix for release gpdb to PPA. Although we can upload the gpdb deb package to the PPA,  it still maybe reject by the PPA due to some unexpected reasons. Here, add a new job **verify ppa release**.  It can make the rest steps continue to run after releasing to PPA successfully

[#168673847]

Authored-by: Tingfang Bao <bbao@pivotal.io>