### PR TITLE
Add applications for determining Server package filenames

### DIFF
--- a/ci/concourse/scripts/determine_package_filename.bash
+++ b/ci/concourse/scripts/determine_package_filename.bash
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+## ======================================================================
+# Determine the correct filename to use for a package given user supplied
+#  information and the current business logic for how to compose that
+#  information into a package name.
+#
+#  Business filename convention:
+#   [Product Shortname]-[Version]-[Platform][Platform Major Version]-[Arch].[Package Type]
+#
+# Usage:
+#   ./determine_package_filename.bash [Version]
+#
+## ======================================================================
+
+function usage() {
+	echo "Usage:"
+	echo "  ./determine_package_filename.bash [Shortname] [Version] [Platform] [Platform Version]"
+	echo ""
+	echo "    Required Parameters"
+	echo "      [Shortname]:          Shortname of the product, e.g. greenplum-db"
+	echo "      [Version]:            Semi-semantic version of the product release, e.g. 6.0.0"
+	echo "      [Platform]:           Platform the package supports, e.g. Redhat, Centos, Ubuntu"
+	echo "      [Platform Version]:   Version of the platform the package supports e.g. 6.0.0"
+	echo ""
+}
+
+## ======================================================================
+# Input validation
+## ======================================================================
+package_shortname="${1}"
+package_version="${2}"
+package_platform="${3}"
+package_platform_version="${4}"
+
+# Check for all inputs
+if [ -z "${1}" ] || [ -z "${2}" ] || [ -z "${3}" ] || [ -z "${4}" ]; then
+	usage
+	exit 1
+fi
+
+# TODO: Validation that the versions are valid semi-semantic.
+#  There is no bash library for this and versions for things like
+#  platform versions are typically MAJOR.MINOR
+
+## ======================================================================
+# Input Sanitization
+## ======================================================================
+# Make everything lowercase
+package_shortname=$(echo "${package_shortname}" | tr '[:upper:]' '[:lower:]')
+package_platform=$(echo "${package_platform}" | tr '[:upper:]' '[:lower:]')
+
+## ======================================================================
+# Calcuated filename conventions
+## ======================================================================
+if [[ "${package_platform}" =~ redhat|rhel|centos ]]; then
+	package_platform="rhel"
+elif [[ "${package_platform}" =~ ubuntu ]]; then
+	package_type="ubuntu"
+else
+	echo "Error: Package platform '${package_platform}' is not implimented"
+	usage
+	exit 1
+fi
+
+if [ "${package_platform}" == "rhel" ]; then
+	package_type="rpm"
+	package_arch="x86_64"
+	# The platform version for rhel platforms is typically specifed like this:
+	#  rhel7, rhel8 or el6, el7.
+	# In following that convention, we only care about the Major version component
+	package_platform_major_version=$(echo "${package_platform_version}" | cut -d"." -f1)
+elif [ "${package_platform}" == "ubuntu" ]; then
+	package_type="deb"
+	package_arch="amd64"
+	# The platform version for ubuntu platforms typically follows LTS releases:
+	#  ubuntu18.04, ubuntu16.04
+	# In following that convention, we only let expect user specify the whole version
+	#  and let input validation error out if it's not a MAJOR.MINOR version schema
+	package_platform_major_version="${package_platform_version}"
+fi
+
+echo "${package_shortname}-${package_version}-${package_platform}${package_platform_major_version}-${package_arch}.${package_type}"

--- a/ci/concourse/scripts/determine_package_product_name.bash
+++ b/ci/concourse/scripts/determine_package_product_name.bash
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+## ======================================================================
+# Determine the correct product name for a given package
+#
+# Usage:
+#   ./determine_package_product_name.bash [Package]
+#
+## ======================================================================
+
+function usage() {
+	echo "Usage:"
+	echo "  ./determine_package_filename.bash [Shortname] [Version] [Platform] [Platform Version]"
+	echo ""
+	echo "    Required Parameters"
+	echo "      [Package]:          Path to a valid Server package, e.g. ./greenplum-db.rpm"
+	echo ""
+}
+
+## ======================================================================
+# Install prerequisite
+## ======================================================================
+# TODO: These should be pre-installed
+yum install -y -q epel-release >/dev/null 2>&1
+yum install -y -q dpkg >/dev/null 2>&1
+
+## ======================================================================
+# Check for prerequisite utilities
+## ======================================================================
+PREREQ_COMMANDS="dpkg rpm"
+
+for COMMAND in ${PREREQ_COMMANDS}; do
+	type "${COMMAND}" >/dev/null 2>&1 || {
+		echo >&2 "Required command line utility \"${COMMAND}\" is not available.  Aborting."
+		exit 1
+	}
+done
+
+## ======================================================================
+# Verify a package was supplied as an arguement and determine type
+## ======================================================================
+package="$1"
+
+# Check if command line argument is given and is a file
+if [ -z "${1}" ]; then
+	usage
+	exit 1
+elif [ ! -f "${package}" ]; then
+	echo ""
+	echo "'${package}' is not a file"
+	usage
+	exit 1
+fi
+
+rpm -qp "${package}" >/dev/null 2>&1
+is_rpm_package=$?
+
+dpkg -I "${package}" >/dev/null 2>&1
+is_deb_package=$?
+
+if [ ! "${is_rpm_package}" -eq 0 ] && [ ! "${is_deb_package}" -eq 0 ]; then
+	echo ""
+	echo "'${package}' is neither an RPM package nor a DEB package"
+	usage
+	exit 1
+fi
+
+## ======================================================================
+# Given package type, determine product name
+## ======================================================================
+if [ "${is_rpm_package}" -eq 0 ]; then
+	package_name=$(rpm -qp --queryformat '%{NAME}' "${package}")
+elif [ "${is_deb_package}" -eq 0 ]; then
+	package_name=$(dpkg-deb -f "${package}" Package)
+fi
+
+echo "${package_name}"

--- a/ci/concourse/scripts/determine_package_server_version.bash
+++ b/ci/concourse/scripts/determine_package_server_version.bash
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+## ======================================================================
+# Identify the version of the Server within a given package.
+#
+#  Currently uses the method of getting the information from the
+#  `git-info.json` file that is built into the binary source tree
+#  at $PREFIX/etc/ . Supports both RPM and DEB package types.
+#
+# Usage:
+#   ./determine_package_server_version.bash [PACKAGE]
+#
+## ======================================================================
+
+function usage() {
+	echo "Usage:"
+	echo "  ./determine_package_server_version.bash [PACKAGE]"
+	echo ""
+	echo "    Required Parameters"
+	echo "      [PACKAGE]:          Path to a valid Server package, e.g. ./greenplum-db.rpm"
+	echo ""
+}
+
+## ======================================================================
+# Install prerequisite
+## ======================================================================
+# TODO: These should be pre-installed
+yum install -y -q epel-release >/dev/null 2>&1
+yum install -y -q dpkg >/dev/null 2>&1
+
+## ======================================================================
+# Check for prerequisite utilities
+## ======================================================================
+PREREQ_COMMANDS="dpkg rpm"
+
+for COMMAND in ${PREREQ_COMMANDS}; do
+	type "${COMMAND}" >/dev/null 2>&1 || {
+		echo >&2 "Required command line utility \"${COMMAND}\" is not available.  Aborting."
+		exit 1
+	}
+done
+
+## ======================================================================
+# Verify a package was supplied as an arguement and determine type
+## ======================================================================
+package="$1"
+
+# Check if command line argument is given and is a file
+if [ -z "${1}" ]; then
+	usage
+	exit 1
+elif [ ! -f "${package}" ]; then
+	echo ""
+	echo "'${package}' is not a file"
+	usage
+	exit 1
+fi
+
+rpm -qp "${package}" >/dev/null 2>&1
+is_rpm_package=$?
+
+dpkg -I "${package}" >/dev/null 2>&1
+is_deb_package=$?
+
+if [ ! "${is_rpm_package}" -eq 0 ] && [ ! "${is_deb_package}" -eq 0 ]; then
+	echo ""
+	echo "'${package}' is neither an RPM package nor a DEB package"
+	usage
+	exit 1
+fi
+
+## ======================================================================
+# Given package type, determine version
+## ======================================================================
+if [ "${is_rpm_package}" -eq 0 ]; then
+	package_version=$(rpm -qp --queryformat '%{VERSION}' "${package}")
+elif [ "${is_deb_package}" -eq 0 ]; then
+	package_version=$(dpkg-deb -f "${package}" Version)
+fi
+
+echo "${package_version}"


### PR DESCRIPTION
### Add applications for determining Server package filenames

This PR is connected to these other PRs:
- https://github.com/pivotal/gp-release/pull/183

#### Specific asks for review:

1. Is the business logic for these three applications correct?
2. I was not pairing on this PR, so a quick check of correctness would be appreciated. I have a dev pipeline here: https://releng.ci.gpdb.pivotal.io/teams/main/pipelines/dev-gpdb6-integration-testing-kris-pre-release-candidates-kmacoskey
3. I made the choice to not add tests for these 3 applications. They are very self contained, simple, and self-documenting. There would likely be more test code then actual application code. Is this an ok choice?

#### Contextual information:

Refer to https://github.com/pivotal/gp-release/pull/183 for background context

#### Implementation Context

1. **determine_package_filename.bash**
   - Determine the correct filename to use for a package given user supplied
   information and the current business logic for how to compose that
   information into a package name.
    - Business filename convention:
    [Product Shortname]-[Version]-[Platform][Platform Major Version]-[Arch].[Package Type]
   - Usage: ./determine_package_filename.bash [Version]

2. **determine_package_product_name.bash**
   - Determine the correct product name for a given package
   - Usage: ./determine_package_product_name.bash [Package]
3. **determine_package_server_version.bash**
    - Identify the version of the Server within a given package.
    - Currently uses the method of getting the information from the
   `git-info.json` file that is built into the binary source tree
   at $PREFIX/etc/ . Supports both RPM and DEB package types.
   - Usage:
    ./determine_package_server_version.bash [PACKAGE]

These three applications when used together are a codification of the
business logic needed to properly name a Server package.

Typical usage is like this:

  ```
  package_version=$(determine_package_server_version.bash server-rpm.rpm)
  package_name=$(determine_package_product_name.bash server-rpm.rpm)
  package_filename=$(determine_package_filename.bash $package_name $package_version redhat 6.0.0)
  mv server-rpm.rpm ${package_filename}
  ```