### PR TITLE
Support compiling gporca within gpdb source codes.

### DIFF
--- a/ci/concourse/scripts/compile_gpdb_oss.bash
+++ b/ci/concourse/scripts/compile_gpdb_oss.bash
@@ -31,16 +31,19 @@ fetch_orca_src() {
 build_xerces() {
 	echo "Building Xerces-C"
 	mkdir -p xerces_patch/concourse
-	if [[ ${INTEGRATE_GPORCA} == 0 ]]; then
-		cp -r orca_src/concourse/xerces-c xerces_patch/concourse
-		cp -r orca_src/patches/ xerces_patch
-	elif [[ ${INTEGRATE_GPORCA} == 1 ]]; then
-		cp -r gpdb_src/src/backend/gporca/concourse/xerces-c xerces_patch/concourse
-		cp -r gpdb_src/src/backend/gporca/patches/ xerces_patch
-	else
+
+	case ${INTEGRATE_GPORCA} in
+	0) orca_src="orca_src" ;;
+	1) orca_src="gpdb_src/src/backend/gporca" ;;
+	*)
 		echo "INTEGRATE GPORCA set error number!"
 		exit 1
-	fi
+		;;
+	esac
+
+	cp -r "${orca_src}/concourse/xerces-c" xerces_patch/concourse
+	cp -r "${orca_src}/patches/" xerces_patch
+
 	/usr/bin/python xerces_patch/concourse/xerces-c/build_xerces.py --output_dir="/usr/local"
 	rm -rf build
 }


### PR DESCRIPTION
  Becasue gporca source codes will be merged into gpdb
  source codes repository, here we need to support compiling
  gporca in two ways.

  1. fetch gporca src from github and compile it.
  2. compile it directly if gporca source codes already in gpdb src
     repo.

Authored-by: Tingfang Bao <bbao@pivotal.io>