### PR TITLE
Check for existence of xerces patch

### DIFF
--- a/ci/concourse/scripts/compile_gpdb_oss.bash
+++ b/ci/concourse/scripts/compile_gpdb_oss.bash
@@ -20,9 +20,6 @@ build_xerces() {
 	orca_src="gpdb_src/src/backend/gporca"
 
 	cp -r "${orca_src}/concourse/xerces-c" xerces_patch/concourse
-	if [ -d "${orca_src}/patches/" ]; then
-		cp -r "${orca_src}/patches/" xerces_patch
-	fi
 
 	/usr/bin/python xerces_patch/concourse/xerces-c/build_xerces.py --output_dir="/usr/local"
 	rm -rf build

--- a/ci/concourse/scripts/compile_gpdb_oss.bash
+++ b/ci/concourse/scripts/compile_gpdb_oss.bash
@@ -20,7 +20,9 @@ build_xerces() {
 	orca_src="gpdb_src/src/backend/gporca"
 
 	cp -r "${orca_src}/concourse/xerces-c" xerces_patch/concourse
-	cp -r "${orca_src}/patches/" xerces_patch
+	if [ -d "${orca_src}/patches/" ]; then
+		cp -r "${orca_src}/patches/" xerces_patch
+	fi
 
 	/usr/bin/python xerces_patch/concourse/xerces-c/build_xerces.py --output_dir="/usr/local"
 	rm -rf build


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/10091 got rid of the
xerces patch we used to apply (this is for master and 6X_STABLE).
Guard against accessing a directory that might no longer exist.