### PR TITLE
Update RPM spec for greenplum-db-6 to create/remove symlink

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -89,5 +89,9 @@ exit 0
 %config(noreplace) %{prefix}/greenplum-db-%{gpdb_version}/greenplum_path.sh
 
 %post
+ln -fsT "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" "${RPM_INSTALL_PREFIX}/greenplum-db" || :
 
 %postun
+if [ "$(readlink -f "${RPM_INSTALL_PREFIX}/greenplum-db")" == "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" ]; then
+  unlink "${RPM_INSTALL_PREFIX}/greenplum-db" || :
+fi


### PR DESCRIPTION
This commit adds two scriptlets to the greenplum-db-6 RPM spec:

1. `%post` which is executed _after_ the package is installed
2. `%postun` which is executed _after_ the package is uninstalled

The post-install scriptlet force creates a symlink to the directory just
installed by this package. This means, in the case of parallel installs,
that last installed package (regardless of version) will have the
`$PREFIX/greeplum-db` symlink pointing to its directory.

The post-uninstall scriptlet checks if the symlink is pointing at the
directory owned by the package; if it is, it removes it.

[#173347015]

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>