### PR TITLE
Update rpm spec for centos6

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -32,7 +32,6 @@ Requires: curl
 # krb5-devel provides libgssapi_krb5.so
 Requires: krb5-devel
 Requires: libcurl
-Requires: libevent
 Requires: libxml2
 Requires: libyaml
 Requires: zlib
@@ -53,6 +52,11 @@ Requires: iproute
 Requires: openssh-server
 %if 0%{?rhel} == 7
 Requires: openssl-libs
+%endif
+%if 0%{?rhel} == 6
+Requires: libevent2
+%else
+Requires: libevent
 %endif
 
 %description


### PR DESCRIPTION
On centos6, we need libevent2.
On centos7, the default libevent version is 2.x, 
but on centos6 , the default libevent verison is 1.x.

This should be merged after : 
https://github.com/pivotal/gp-image-baking/pull/85
https://github.com/greenplum-db/gpdb/pull/10405