### PR TITLE
GP 5: Support local RPM builds with BIN_GPDB_TARGZ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,17 +137,18 @@ local-build-gpdb6-deb:
 local-build-rpm:
 	bin/create_rpm_package.bash
 
-local-build-gpdb5-centos6-rpm:
-	docker run -it -v $$PWD/:/tmp/greenplum-database-release \
-	-e GPDB_VERSION=${GPDB_VERSION} -e PLATFORM=rhel6 \
-	-w /tmp/greenplum-database-release \
-	pivotaldata/centos-gpdb-dev:6-gcc6.2-llvm3.7 /tmp/greenplum-database-release/bin/create_gpdb5_rpm_package.sh
+.PHONY: local-build-gpdb5-centos6-rpm
+local-build-gpdb5-centos6-rpm: CENTOS_VERSION=6
+local-build-gpdb5-centos6-rpm: local-build-gpdb5-rpm
 
-local-build-gpdb5-centos7-rpm:
-	docker run -it -v $$PWD/:/tmp/greenplum-database-release \
-	-e GPDB_VERSION=${GPDB_VERSION} -e PLATFORM=rhel7 \
-	-w /tmp/greenplum-database-release \
-	pivotaldata/centos-gpdb-dev:7-gcc6.2-llvm3.7 /tmp/greenplum-database-release/bin/create_gpdb5_rpm_package.sh
+.PHONY: local-build-gpdb5-centos7-rpm
+local-build-gpdb5-centos7-rpm: CENTOS_VERSION=7
+local-build-gpdb5-centos7-rpm: local-build-gpdb5-rpm
+
+.PHONY: local-build-gpdb5-rpm
+local-build-gpdb5-rpm :
+		CENTOS_VERSION=$(CENTOS_VERSION) ./bin/run_docker_gpdb5_rpm_package.sh
+
 
 local-build-gpdb5-deb:
 	bin/create_gpdb5_deb_package.bash

--- a/README.md
+++ b/README.md
@@ -56,23 +56,16 @@ Passed check! Install /tmp/build/gpdb_deb_installer/greenplum-db-<gpdb_version>-
 
 ## How to use the application to create a RPM package for gpdb5 locally
 
-```bash
-cd greeplum-database-release
-mkdir bin_gpdb
-
-# download `bin_gpdb.tar.gz` to `greenplum-database-release/bin_gpdb/bin_gpdb.tar.gz`
-```
-
 For rhel6
 
 ```bash
-GPDB_VERSION=<GPDB_VERSION> make local-build-gpdb5-centos6-rpm
+GPDB_VERSION=<GPDB_VERSION> BIN_GPDB_TARGZ=<path-to-tar-archive> make local-build-gpdb5-centos6-rpm
 ```
 
 For rhel7
 
 ```bash
-GPDB_VERSION=<GPDB_VERSION> make local-build-gpdb5-centos7-rpm
+GPDB_VERSION=<GPDB_VERSION> BIN_GPDB_TARGZ=<path-to-tar-archive> make local-build-gpdb5-centos7-rpm
 ```
 
 ## How to use the open source code to create a GPDB5 source DEB package locally

--- a/bin/run_docker_gpdb5_rpm_package.sh
+++ b/bin/run_docker_gpdb5_rpm_package.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+main() {
+	local platform
+	local docker_image_tag
+	case "${CENTOS_VERSION}" in
+	[6-7])
+		platform="rhel${CENTOS_VERSION}"
+		docker_image_tag="${CENTOS_VERSION}-gcc6.2-llvm3.7"
+		;;
+	*)
+		printf "Unexpected value for \$CENTOS_VERSION='%s'\n" "${CENTOS_VERSION}"
+		exit 1
+		;;
+	esac
+
+	local bin_gpdb_path
+	bin_gpdb_path="$(readlink -f "${BIN_GPDB_TARGZ}")"
+
+	test -f "${bin_gpdb_path}" || {
+		printf "File in \$BIN_GPDB_TARGZ does not exist\n"
+		exit 1
+	}
+
+	docker run -it \
+		-v "${PWD}":/tmp/greenplum-database-release \
+		-v "${bin_gpdb_path}":/tmp/greenplum-database-release/bin_gpdb/bin_gpdb.tar.gz \
+		-w /tmp/greenplum-database-release \
+		-e GPDB_VERSION="${GPDB_VERSION}" \
+		-e PLATFORM="${platform}" \
+		pivotaldata/centos-gpdb-dev:"${docker_image_tag}" \
+		/tmp/greenplum-database-release/bin/create_gpdb5_rpm_package.sh
+}
+
+main "${@}"


### PR DESCRIPTION
The code for building a GP 5 RPM locally assumed that you had a
tar archive named "bin_gpdb/bin_gpdb.tar.gz" in the current working
directory (i.e., in "greenplum-database-release"). This commit uses the
value of the environment variable BIN_GPDB_TARGZ to determine which tar
archive to build in to an RPM.

If the environment variable is not set or does not point to a regular
file, the code prints an error message and exits.

[#173785658]

Co-authored-by: Brent Doil <bdoil@vmware.com>
Co-authored-by: Bradford D. Boyle <bradfordb@vmware.com>