### PR TITLE
Add support for GPDB 4.3 RPM packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,32 +129,28 @@ lint: shfmt
 shfmt:
 	docker run --rm -v ${PWD}:/code mvdan/shfmt:v2.6.4 -d /code
 
-local-build-gpdb6-deb:
-	bin/create_gpdb6_deb_package.bash
+## ----------------------------------------------------------------------
+## Local packaging targets
+## ----------------------------------------------------------------------
 
-.PHONY: local-build-gpdb6-centos6-rpm
-local-build-gpdb6-centos6-rpm: CENTOS_VERSION=6
-local-build-gpdb6-centos6-rpm: local-build-gpdb6-rpm
+GPDB_MAJOR_VERSION = $(shell echo "${GPDB_VERSION}" | cut -d '.' -f1)
 
-.PHONY: local-build-gpdb6-centos7-rpm
-local-build-gpdb6-centos7-rpm: CENTOS_VERSION=7
-local-build-gpdb6-centos7-rpm: local-build-gpdb6-rpm
+.PHONY: local-build-gpdb-rpm
+local-build-gpdb-rpm:
+	$(MAKE) local-build-gpdb$(GPDB_MAJOR_VERSION)-rpm
 
 .PHONY: local-build-gpdb6-rpm
 local-build-gpdb6-rpm:
-	CENTOS_VERSION=$(CENTOS_VERSION) bin/create_gpdb6_rpm_package.bash
+	bin/create_gpdb6_rpm_package.bash
 
-.PHONY: local-build-gpdb5-centos6-rpm
-local-build-gpdb5-centos6-rpm: CENTOS_VERSION=6
-local-build-gpdb5-centos6-rpm: local-build-gpdb5-rpm
+.PHONY: local-build-gpdb5-rpm local-build-gpdb4-rpm
+local-build-gpdb5-rpm local-build-gpdb4-rpm:
+	bin/create_gpdb5_rpm_package.bash
 
-.PHONY: local-build-gpdb5-centos7-rpm
-local-build-gpdb5-centos7-rpm: CENTOS_VERSION=7
-local-build-gpdb5-centos7-rpm: local-build-gpdb5-rpm
-
-.PHONY: local-build-gpdb5-rpm
-local-build-gpdb5-rpm :
-	CENTOS_VERSION=$(CENTOS_VERSION) ./bin/create_gpdb5_rpm_package.bash
-
+.PHONY: local-build-gpdb5-deb
 local-build-gpdb5-deb:
 	bin/create_gpdb5_deb_package.bash
+
+.PHONY: local-build-gpdb6-deb
+local-build-gpdb6-deb:
+	bin/create_gpdb6_deb_package.bash

--- a/README.md
+++ b/README.md
@@ -17,85 +17,45 @@ Currently this mostly consists of a Concourse based application (task yaml, task
 
 The full behavior and user experience of the packages involves many code bases and components coming together. The following is documentation that captures in one location the topics relates to a Greenplum Server package.
 
-1. [Greenplum Server RPM Packaging Specification](Greenplum-Server-RPM-Packaging-Specification.md)
+[Greenplum Server RPM Packaging Specification](Greenplum-Server-RPM-Packaging-Specification.md)
 
-## How to use the application to create a RPM package locally
+## Build a RPM package locally
 
-1. For rhel6
-
-    ```bash
-    BIN_GPDB_TARGZ=/path/to/bin_gpdb.tar.gz make local-build-gpdb6-centos6-rpm
-    ```
-
-    The output like:
-
-    ```console
-    Creating Centos6 RPM Package...
-    Cloning into '/tmp/create-package/greenplum-database-release'...
-    ...
-    ...
-    Complete!
-    Passed check! Install /tmp/build/gpdb_rpm_installer/greenplum-db-<gpdb_version>-rhel6-x86_64.rpm package successfully.
-    ```
-
-2. For rhel7
-
-    ```bash
-    BIN_GPDB_TARGZ=/path/to/bin_gpdb.tar.gz make local-build-gpdb6-centos7-rpm
-    ```
-
-    The output like:
-
-    ```console
-    Creating Centos7 RPM Package...
-    Cloning into '/tmp/create-package/greenplum-database-release'...
-    ...
-    ...
-    Complete!
-    Passed check! Install /tmp/build/gpdb_rpm_installer/greenplum-db-<gpdb_version>-rhel7-x86_64.rpm package successfully.
-    ```
-
-## How to use the application to create a GPDB6 DEB package locally
-
-```bash
-BIN_GPDB_TARGZ=/path/to/bin_gpdb.tar.gz make local-build-gpdb6-deb
+Remember the tarball to be used for the build
+```console
+export BIN_GPDB_TARGZ=/path/bin/bin_gpdb.tar.gz
 ```
 
-The output like:
+### for CentOs 7
 
 ```console
-Creating DEB Package...
-Cloning into '/tmp/create-package/greenplum-database-release'...
-...
-...
-done.
-Passed check! Install /tmp/build/gpdb_deb_installer/greenplum-db-<gpdb_version>-ubuntu18.04-amd64.deb package successfully.
+export CENTOS_VERSION=7
+
+GPDB_VERSION=6.x.x make local-build-gpdb-rpm
 ```
 
-## How to use the application to create a RPM package for gpdb5 locally
+### for CentOs 6
 
-For rhel6
+Just change the `CENTOS_VERSION` to `6`, like:
 
-```bash
-GPDB_VERSION=<GPDB_VERSION> BIN_GPDB_TARGZ=<path-to-tar-archive> make local-build-gpdb5-centos6-rpm
+```console
+export CENTOS_VERSION=6
 ```
 
-For rhel7
+## Build a DEB package locally
 
-```bash
-GPDB_VERSION=<GPDB_VERSION> BIN_GPDB_TARGZ=<path-to-tar-archive> make local-build-gpdb5-centos7-rpm
+## for GP6 using binary tarball
+
+```console
+export BIN_GPDB_TARGZ=/path/to/bin_gpdb.tar.gz
+
+GPDB_VERSION=6.x.x make local-build-gpdb6-deb
 ```
 
-## How to use the open source code to create a GPDB5 source DEB package locally
+## for GP5 using source code
 
-1. Install yq, please refer to the [installation guide](https://github.com/mikefarah/yq#install)
-2. `make local-build-gpdb5-deb`
+`yq` is required, please refer to the [installation guide](https://github.com/mikefarah/yq#install)
 
-    The output like:
-
-    ```console
-    Creating DEB Package...
-    ...
-    ...
-    Done. Please find the source package under /tmp/build/debian_source_files
-    ```
+```console
+GPDB_VERSION=5.x.x make local-build-gpdb5-deb
+```

--- a/bin/create_gpdb5_rpm_package.bash
+++ b/bin/create_gpdb5_rpm_package.bash
@@ -24,6 +24,9 @@ main() {
 		exit 1
 	}
 
+	local gpdb_major_version
+	gpdb_major_version="$(echo "${GPDB_VERSION}" | cut -d '.' -f1)"
+
 	docker run -it \
 		-v "${PWD}":/tmp/greenplum-database-release \
 		-v "${bin_gpdb_path}":/tmp/bin_gpdb/bin_gpdb.tar.gz \
@@ -35,7 +38,7 @@ main() {
 		-e GPDB_DESCRIPTION="Greenplum Database" \
 		-e GPDB_GROUP="Applications/Databases" \
 		-e GPDB_LICENSE="Pivotal Software EULA" \
-		-e GPDB_NAME="greenplum-db-5" \
+		-e GPDB_NAME="greenplum-db-${gpdb_major_version}" \
 		-e GPDB_PREFIX="/usr/local" \
 		-e GPDB_RELEASE=1 \
 		-e GPDB_SUMMARY="Greenplum-DB" \

--- a/bin/create_gpdb5_rpm_package.bash
+++ b/bin/create_gpdb5_rpm_package.bash
@@ -17,7 +17,7 @@ main() {
 	esac
 
 	local bin_gpdb_path
-	bin_gpdb_path="$(readlink -f "${BIN_GPDB_TARGZ}")"
+	bin_gpdb_path="${BIN_GPDB_TARGZ}"
 
 	test -f "${bin_gpdb_path}" || {
 		printf "File in \$BIN_GPDB_TARGZ does not exist\n"
@@ -47,4 +47,4 @@ main() {
 		/tmp/greenplum-database-release/ci/concourse/scripts/build_gpdb5_rpm.sh
 }
 
-main "${@}"
+main

--- a/bin/create_gpdb6_rpm_package.bash
+++ b/bin/create_gpdb6_rpm_package.bash
@@ -9,7 +9,7 @@ export BUILD_IMAGE=centos:${CENTOS_VERSION}
 build_rpm_env_file() {
 	cat <<EOF >>"${BUILD_ENV_FILE}"
 PLATFORM=rhel${CENTOS_VERSION}
-GPDB_NAME=greenplum-db
+GPDB_NAME=greenplum-db-6
 GPDB_RELEASE=1
 GPDB_SUMMARY=Greenplum-DB
 GPDB_LICENSE=Pivotal\ Software\ EULA

--- a/ci/concourse/scripts/greenplum-db-4.spec
+++ b/ci/concourse/scripts/greenplum-db-4.spec
@@ -1,0 +1,75 @@
+# Copyright (C) 2019-Present VMware, and affiliates Inc. All rights reserved.
+# This program and the accompanying materials are made available under the
+# terms of the under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain a
+# copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+%{!?gpdb_major_version:%global gpdb_major_version 4}
+
+# Disable automatic dependency processing both for requirements and provides
+AutoReqProv: no
+
+Name: greenplum-db-4
+Version: %{rpm_gpdb_version}
+Release: %{gpdb_release}%{?dist}
+Summary: Greenplum-DB
+Group: Applications/Databases
+License: %{gpdb_license}
+URL: %{gpdb_url}
+Source0: gpdb.tar.gz
+Prefix: /usr/local
+
+# in sles11, the buildroot macro is not defined, it is not a problem for sles12, centos6, centos7
+Buildroot: %{_topdir}/BUILD/%{name}-%{version}-%{release}.%{_arch}
+
+%description
+Greenplum Database
+
+%prep
+# If the rpm_gpdb_version macro is not defined, it gets interpreted as a literal string
+#  The multiple '%' is needed to escape the macro
+if [ %{rpm_gpdb_version} = '%%{rpm_gpdb_version}' ] ; then
+  echo "The macro (variable) rpm_gpdb_version must be supplied as rpmbuild ... --define='rpm_gpdb_version [VERSION]'"
+  exit 1
+fi
+if [ %{gpdb_version} = '%%{gpdb_version}' ] ; then
+  echo "The macro (variable) gpdb_version must be supplied as rpmbuild ... --define='gpdb_version [VERSION]'"
+  exit 1
+fi
+
+%setup -q -c -n %{name}-%{gpdb_version}
+
+%install
+mkdir -p %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
+cp -R * %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
+
+# Disable build root policy trying to generate %.pyo/%.pyc
+exit 0
+
+%files
+%{prefix}/greenplum-db-%{gpdb_version}
+%config(noreplace) %{prefix}/greenplum-db-%{gpdb_version}/greenplum_path.sh
+
+# Normally we would do this in a %post scriptlet but the existing greenplum-db (5.x.x)
+# unconditionally removes the symlink as part of its %postun scriptlet which is executed *after*
+# the new package's %post scriptlet.
+# Creating the link in %posttrans should be the last scriptlet executed.
+%post
+if [ ! -e "${RPM_INSTALL_PREFIX}/greenplum-db" ] || [ -L "${RPM_INSTALL_PREFIX}/greenplum-db" ];then
+  ln -fsT "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" "${RPM_INSTALL_PREFIX}/greenplum-db" || :
+  # Set GPHOME to the installation prefix
+  sed -i -e "1 s~^\(GPHOME=\).*~\1${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}~" "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}/greenplum_path.sh"
+else
+    echo "the expected symlink was not created because a file exists at that location"
+fi
+
+%postun
+if [ "$(readlink -f "${RPM_INSTALL_PREFIX}/greenplum-db")" == "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" ]; then
+  unlink "${RPM_INSTALL_PREFIX}/greenplum-db" || :
+fi


### PR DESCRIPTION
- GPDB4.3 RPM package is based on GPDB5 RPM packaging script.
- New `greenplum-db-4.spec` to remove the `Obsoletes` attribute.
- Refactor the make target `local-build-gpdb-rpm` to detect the major version automatically.