### PR TITLE
Support creating Greenplum 7 Server DEB packages locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,14 @@ local-build-gpdb6-rpm local-build-gpdb7-rpm:
 local-build-gpdb5-rpm local-build-gpdb4-rpm:
 	bin/create_gpdb5_rpm_package.bash
 
+.PHONY:
+local-build-gpdb-deb:
+	$(MAKE) local-build-gpdb$(GPDB_MAJOR_VERSION)-deb
+
 .PHONY: local-build-gpdb5-deb
 local-build-gpdb5-deb:
 	bin/create_gpdb5_deb_package.bash
 
-.PHONY: local-build-gpdb6-deb
-local-build-gpdb6-deb:
+.PHONY: local-build-gpdb6-deb local-build-gpdb7-deb
+local-build-gpdb6-deb local-build-gpdb7-deb:
 	bin/create_gpdb6_deb_package.bash

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ export GPDB_VERSION=6.x.x
 ### Execution
 
 ```bash
-make local-build-gpdb6-deb
+make local-build-gpdb-deb
 ```

--- a/ci/concourse/scripts/build_gpdb_deb.bash
+++ b/ci/concourse/scripts/build_gpdb_deb.bash
@@ -26,6 +26,7 @@ function build_deb() {
 
 	local __package_name=$1
 	local __gpdb_binary_tarbal=$2
+	gpdb_major_version="$(echo "${GPDB_VERSION}" | cut -d '.' -f1)"
 
 	mkdir -p "deb_build_dir"
 
@@ -80,7 +81,7 @@ NOTICE_EOF
 	fi
 
 	cat <<EOF >"${__package_name}/DEBIAN/control"
-Package: greenplum-db-6
+Package: greenplum-db-${gpdb_major_version}
 Priority: extra
 Maintainer: gp-releng@pivotal.io
 Architecture: ${GPDB_BUILDARCH}


### PR DESCRIPTION
- update README to use one make command for gpdb5/6/7 deb package build
- update Makefile and build_gpdb_deb.bash to be shared between gpdb6 and gpdb7

Authored-by: Ning Wu <ningw@vmware.com>