### PR TITLE
Remove unused variable tanzunet-s3-filepath-prefix

### DIFF
--- a/ci/concourse/pipelines/gpdb-opensource-release.yml
+++ b/ci/concourse/pipelines/gpdb-opensource-release.yml
@@ -567,4 +567,3 @@ jobs:
       TANZUNET_METADATA_FILE: ((tanzunet-metadata-file-path))
       TANZUNET_REFRESH_TOKEN: ((tanzunet-refresh-token))
       TANZUNET_PRODUCT_SLUG: ((tanzunet-product-slug))
-      TANZUNET_S3_FILEPATH_PREFIX: ((tanzunet-s3-filepath-prefix))

--- a/ci/concourse/tasks/push-to-tanzunet.yml
+++ b/ci/concourse/tasks/push-to-tanzunet.yml
@@ -18,7 +18,6 @@ params:
   TANZUNET_ENDPOINT:
   TANZUNET_REFRESH_TOKEN:
   TANZUNET_PRODUCT_SLUG:
-  TANZUNET_S3_FILEPATH_PREFIX:
   TANZUNET_METADATA_FILE:
 run:
   path: greenplum-database-release/ci/concourse/scripts/push-to-tanzunet.bash

--- a/ci/concourse/vars/greenplum-database-release.dev.yml
+++ b/ci/concourse/vars/greenplum-database-release.dev.yml
@@ -11,4 +11,3 @@ debian-package-maintainer-email: gpbosh@pivotal.io
 tanzunet-endpoint: "https://pivnet-integration.cfapps.io/"
 tanzunet-product-slug: toolsmiths-gpdb-test
 tanzunet-metadata-file-path: ci/tanzunet/metadata.yml
-tanzunet-s3-filepath-prefix: product-files/toolsmiths-gpdb-test

--- a/ci/concourse/vars/greenplum-database-release.prod.yml
+++ b/ci/concourse/vars/greenplum-database-release.prod.yml
@@ -16,10 +16,9 @@ debian-release-git-remote: https://github.com/greenplum-db/debian-release.git
 debian-release-git-branch: master
 debian-package-maintainer-fullname: 'gpdb team'
 debian-package-maintainer-email: gpdb-bosh@pivotal.io
-tanzunet-client-version: v4.1.2
+tanzunet-client-version: v4.2.0
 tanzunet-client-git-remote: git@github.com:pivotal/gp-tanzunet-client.git
 tanzunet-client-branch: main
 tanzunet-endpoint: "https://network.pivotal.io"
 tanzunet-product-slug: toolsmiths-gpdb-test
 tanzunet-metadata-file-path: ci/tanzunet/metadata.yml
-tanzunet-s3-filepath-prefix: product_files/toolsmiths-gpdb-test


### PR DESCRIPTION
It is because the variable tanzunet-s3-filepath-prefix can be retrieved from the
tanzunet API using product_slug

Authored-by: Ning Wu <ningw@vmware.com>