### PR TITLE
On Photon glibc-iconv is required to perform transcoding.

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -65,6 +65,7 @@ Requires: libevent
 %endif
 %if 0%{?rhel:0}
 Requires: curl-libs
+Requires: glibc-iconv
 %endif
 %description
 Greenplum Database


### PR DESCRIPTION
- If not available, xerces will fail with error
"Could not load a transcoding service"

Authored-by: Brent Doil <bdoil@vmware.com>