### PR TITLE
Update gpdb_rpm_installer_centos6 resource regexp to be clear

### DIFF
--- a/ci/concourse/pipelines/gpdb-opensource-release.yml
+++ b/ci/concourse/pipelines/gpdb-opensource-release.yml
@@ -167,7 +167,7 @@ resources:
   source:
     bucket: ((gcs-bucket-for-oss))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: greenplum-oss-server/released/gpdb6/greenplum-db-(.*)-rhel6-x86_64.rpm
+    regexp: greenplum-oss-server/released/gpdb6/open-source-greenplum-db-(.*)-rhel6-x86_64.rpm
 
 ## RHEL7 Resources
 - name: bin_gpdb_centos7
@@ -192,7 +192,7 @@ resources:
   source:
     bucket: ((gcs-bucket-for-oss))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: greenplum-oss-server/released/gpdb6/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: greenplum-oss-server/released/gpdb6/open-source-greenplum-db-(.*)-rhel7-x86_64.rpm
 
 
 ## Photon3 Resources


### PR DESCRIPTION
Since for the open source gpdb, we add prefix 'open-source' for the package
name. So update the resource regexp definition to make them consistent.

Authored-by: Ning Wu <ningw@vmware.com>