### PR TITLE
[GP-312] Photon RPM dependency updates

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -31,44 +31,84 @@ Obsoletes: greenplum-db >= %{gpdb_major_version}.0.0
 Source0: gpdb.tar.gz
 Prefix: /usr/local
 
+%if 0%{?rhel}
 Requires: apr apr-util
 Requires: bash
 Requires: bzip2
 Requires: curl
-# krb5-devel provides libgssapi_krb5.so
+Requires: iproute
 Requires: krb5-devel
+Requires: less
+Requires: libcurl
 Requires: libxml2
 Requires: libyaml
-Requires: zlib
+Requires: net-tools
 Requires: openldap
 Requires: openssh
+Requires: openssh-clients
+Requires: openssh-server
 Requires: openssl
 Requires: perl
 Requires: readline
 Requires: rsync
 Requires: sed
 Requires: tar
-Requires: zip
-Requires: net-tools
-Requires: less
-Requires: openssh-clients
 Requires: which
-Requires: iproute
-Requires: openssh-server
+Requires: zip
+Requires: zlib
+%endif
+
 %if "%{platform}" == "rhel7"
 Requires: openssl-libs
-Requires: libcurl
 %endif
 %if "%{platform}" == "rhel6"
 Requires: libevent2
-Requires: libcurl
-%else
-Requires: libevent
 %endif
+
 %if "%{platform}" == "photon3"
+Requires: apr
+Requires: bash
+Requires: bzip2-libs
+Requires: coreutils
 Requires: curl-libs
+Requires: cyrus-sasl
+Requires: e2fsprogs-libs
+Requires: findutils
+Requires: gawk
+Requires: gdbm
 Requires: glibc-iconv
+Requires: grep
+Requires: gzip
+Requires: iproute2
+Requires: iputils
+Requires: krb5
+Requires: less
+Requires: libevent
+Requires: libgcc == 7.3.0
+Requires: libssh2
+Requires: libstdc++ == 7.3.0
+Requires: libxml2
+Requires: libyaml
+Requires: Linux-PAM
+Requires: ncurses-libs
+Requires: net-tools
+Requires: openldap
+Requires: openssh-clients
+Requires: openssl
+Requires: perl
+Requires: procps-ng
+Requires: readline
+Requires: rsync
+Requires: sed
+Requires: sqlite-libs
+Requires: tar
+Requires: util-linux
+Requires: util-linux-libs
+Requires: which
+Requires: zip
+Requires: zlib
 %endif
+
 %description
 Greenplum Database
 

--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -22,45 +22,84 @@ URL: %{gpdb_url}
 Source0: gpdb.tar.gz
 Prefix: /usr/local
 
+%if 0%{?rhel}
 Requires: apr apr-util
 Requires: bash
 Requires: bzip2
 Requires: curl
-# krb5-devel provides libgssapi_krb5.so
+Requires: iproute
 Requires: krb5-devel
+Requires: less
 Requires: libcurl
 Requires: libxml2
 Requires: libyaml
-Requires: zlib
+Requires: net-tools
 Requires: openldap
 Requires: openssh
+Requires: openssh-clients
+Requires: openssh-server
 Requires: openssl
 Requires: perl
 Requires: readline
 Requires: rsync
 Requires: sed
 Requires: tar
-Requires: zip
-Requires: net-tools
-Requires: less
-Requires: openssh-clients
 Requires: which
-Requires: iproute
-Requires: openssh-server
+Requires: zip
+Requires: zlib
+%endif
+
 %if "%{platform}" == "rhel7"
 Requires: openssl-libs
-Requires: libcurl
 %endif
 %if "%{platform}" == "rhel6"
 Requires: libevent2
-Requires: libcurl
-%else
-Requires: libevent
 %endif
+
 %if "%{platform}" == "photon3"
+Requires: apr
+Requires: bash
+Requires: bzip2-libs
+Requires: coreutils
 Requires: curl-libs
+Requires: cyrus-sasl
+Requires: e2fsprogs-libs
+Requires: findutils
+Requires: gawk
+Requires: gdbm
 Requires: glibc-iconv
+Requires: grep
+Requires: gzip
+Requires: iproute2
+Requires: iputils
+Requires: krb5
+Requires: less
+Requires: libevent
+Requires: libgcc == 7.3.0
+Requires: libssh2
+Requires: libstdc++ == 7.3.0
+Requires: libxml2
+Requires: libyaml
+Requires: Linux-PAM
+Requires: ncurses-libs
+Requires: net-tools
+Requires: openldap
+Requires: openssh-clients
+Requires: openssl
+Requires: perl
+Requires: procps-ng
+Requires: readline
+Requires: rsync
+Requires: sed
+Requires: sqlite-libs
+Requires: tar
+Requires: util-linux
+Requires: util-linux-libs
+Requires: which
+Requires: zip
+Requires: zlib
 %endif
+
 %description
 Greenplum Database
 


### PR DESCRIPTION
The required packages for the Greenplum 6 & 7 RPM differ significantly between Centos 6/Centos 7 and Photon. This commit better defines the different package requirements in the spec files.