### PR TITLE
Generate python bytecode when installing packages

### DIFF
--- a/ci/concourse/scripts/build-gpdb-clients-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-clients-deb.bash
@@ -23,9 +23,18 @@ set -e
 cd ${GPDB_PREFIX}/
 rm -f ${GPDB_NAME}
 ln -s ${GPDB_NAME}-${GPDB_VERSION} ${GPDB_NAME}
+cd ${GPDB_NAME}-${GPDB_VERSION}
+ext/python/bin/python -m compileall -q -x test .
 exit 0
 EOF
 	chmod 0775 "${__package_name}/DEBIAN/postinst"
+	cat <<EOF >"${__package_name}/DEBIAN/prerm"
+#!/bin/sh
+set -e
+dpkg -L "${__package_name}" | grep '\.py$' | while read file; do rm -f "${file}"[co] >/dev/null; done
+exit 0
+EOF
+	chmod 0775 "${__package_name}/DEBIAN/prerm"
 	cat <<EOF >"${__package_name}/DEBIAN/postrm"
 #!/bin/sh
 set -e

--- a/ci/concourse/scripts/build-gpdb-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-deb.bash
@@ -38,9 +38,18 @@ set -e
 cd ${GPDB_PREFIX}/
 rm -f ${GPDB_NAME}
 ln -s ${GPDB_NAME}-${GPDB_VERSION} ${GPDB_NAME}
+cd ${GPDB_NAME}-${GPDB_VERSION}
+ext/python/bin/python -m compileall -q -x test .
 exit 0
 EOF
 	chmod 0775 "${__package_name}/DEBIAN/postinst"
+	cat <<EOF >"${__package_name}/DEBIAN/prerm"
+#!/bin/sh
+set -e
+dpkg -L "${__package_name}" | grep '\.py$' | while read file; do rm -f "${file}"[co] >/dev/null; done
+exit 0
+EOF
+	chmod 0775 "${__package_name}/DEBIAN/prerm"
 	cat <<EOF >"${__package_name}/DEBIAN/postrm"
 #!/bin/sh
 set -e

--- a/ci/concourse/scripts/compile-gpdb-oss.bash
+++ b/ci/concourse/scripts/compile-gpdb-oss.bash
@@ -102,7 +102,6 @@ include_dependencies() {
 	# vendor pkgconfig files
 	for path in "${library_search_path[@]}"; do if [[ -d "${path}/pkgconfig" ]]; then for pkg in "${pkgconfigs[@]}"; do find -L "$path"/pkgconfig/ -name "$pkg" -exec cp -avn '{}' "${greenplum_install_dir}/lib/pkgconfig" \;; done; fi; done
 
-	# Vendor python
 	echo "Copying python from ${PYTHONHOME} into ${greenplum_install_dir}/ext/python..."
 	cp --archive "${PYTHONHOME}"/* "${greenplum_install_dir}/ext/python"
 
@@ -116,11 +115,8 @@ export_gpdb() {
 	local tarball="${2}"
 
 	pushd "${greenplum_install_dir}"
-	(
-		# shellcheck disable=SC1091
-		source greenplum_path.sh
-		python -m compileall -q -x test .
-	)
+	# Remove python bytecode
+	find . -type f \( -iname \*.pyc -o -iname \*.pyo \) -delete
 	tar -czf "${tarball}" ./*
 	popd
 }

--- a/ci/concourse/scripts/gpdb-clients.spec
+++ b/ci/concourse/scripts/gpdb-clients.spec
@@ -71,6 +71,9 @@ fi
 rm -rf %{buildroot}
 mkdir -p %{buildroot}%{bin_gpdb}
 cp -R * %{buildroot}%{bin_gpdb}
+pushd %{buildroot}/%{bin_gpdb}
+ext/python/bin/python -m compileall -q -x test .
+popd
 
 # Disable build root policy trying to generate %.pyo/%.pyc
 exit 0

--- a/ci/concourse/scripts/greenplum-db-5.spec
+++ b/ci/concourse/scripts/greenplum-db-5.spec
@@ -50,6 +50,9 @@ fi
 mkdir -p %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 cp -R * %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 
+pushd %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
+ext/python/bin/python -m compileall -q -x test .
+popd
 # Disable build root policy trying to generate %.pyo/%.pyc
 exit 0
 

--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -130,7 +130,9 @@ fi
 %install
 mkdir -p %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 cp -R * %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
-
+pushd %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
+ext/python/bin/python -m compileall -q -x test .
+popd
 # Disable build root policy trying to generate %.pyo/%.pyc
 exit 0
 

--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -122,6 +122,10 @@ fi
 mkdir -p %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 cp -R * %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 
+pushd %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
+ext/python/bin/python -m compileall -q -x test .
+popd
+
 # Disable build root policy trying to generate %.pyo/%.pyc
 exit 0
 

--- a/ci/concourse/tests/gpdb6/clients/rpm/controls/gpdb6-clients-rpm.rb
+++ b/ci/concourse/tests/gpdb6/clients/rpm/controls/gpdb6-clients-rpm.rb
@@ -23,29 +23,29 @@ control 'Category:clients-rpm_metadata' do
 
     title 'rpm metadata is valid'
     desc 'The rpm metadata is valid per product requirements'
-  
+
     # Note: many of the rpm metadata fields (tags) are required when building.
     # Therefore this is no need to test if they aren't specified (they have to
     # be).
-  
+
     describe command("rpm -qip #{gpdb_clients_path}/greenplum-db-clients-#{gpdb_clients_version}-#{gpdb_clients_arch}-x86_64.rpm | grep Group") do
       # If group is not specified, it's default is "unspecified"
       # starting w/ GPDB6, we discontinued defining the group
       # https://fedoraproject.org/wiki/RPMGroups#DEPRECATION_ALERT
       its('stdout') { should match /Group       : Unspecified/ }
     end
-  
+
     describe command("rpm -qip #{gpdb_clients_path}/greenplum-db-clients-#{gpdb_clients_version}-#{gpdb_clients_arch}-x86_64.rpm | grep URL") do
       # If URL is not specified, the field will be ommited
       its('stdout') { should match /URL/ }
     end
-  
+
     # Test specified URL is reachable
     describe command("curl -s --head $(rpm -qip #{gpdb_clients_path}/greenplum-db-clients-#{gpdb_clients_version}-#{gpdb_clients_arch}-x86_64.rpm | grep URL | awk \"{print $3\"}) | head -n 1 | grep 'HTTP/[1-2].* [23]..'") do
       # If URL is not specified, the field will be ommited
       its('stdout') { should match /200/ }
     end
-  
+
 end
 
 control 'Category:clients-rpm-functionality' do
@@ -116,6 +116,10 @@ control 'Category:clients-rpm-functionality' do
     # Should create symlink
     describe file('/usr/local/greenplum-db-clients') do
       it { should be_linked_to "/usr/local/greenplum-db-clients-#{gpdb_clients_version}" }
+    end
+    # should generate bytecode
+    describe file("/usr/local/greenplum-db-clients/ext/python/lib/python2.7/cmd.pyc") do
+      it { should exist}
     end
 
     # Should be uninstallable
@@ -205,24 +209,24 @@ control 'Category:clients-rpm_relocateable' do
 
     title 'RPM is relocateable'
     desc 'The RPM should allow specifying an installation PREFIX and handle accordingly'
-  
+
     prefix="/opt"
-  
+
     # Should not already be installed
     describe command('rpm -q greenplum-db-clients') do
       its('stdout') { should match /package greenplum-db-clients is not installed/ }
     end
-  
+
     # Should be installable at a user given prefix (/opt as a test example)
     describe command("rpm --prefix=#{prefix} -ivh #{gpdb_clients_path}/greenplum-db-clients-#{gpdb_clients_version}-#{gpdb_clients_arch}-x86_64.rpm") do
       its('exit_status') { should eq 0 }
     end
-  
+
     # Should create the proper symbolic link
     describe file("#{prefix}/greenplum-db-clients") do
       it { should be_linked_to "#{prefix}/greenplum-db-clients-#{gpdb_clients_version}" }
     end
-  
+
     # Prefix should be reflected in greenplum_clients_path.sh
     describe file("#{prefix}/greenplum-db-clients/greenplum_clients_path.sh") do
       its('content') { should match /GPHOME_CLIENTS=#{prefix}\/greenplum-db-clients-.*/ }
@@ -238,12 +242,12 @@ control 'Category:clients-rpm_relocateable' do
     describe command('rpm -q greenplum-db-clients') do
       its('stdout') { should match /greenplum-db-clients-*/ }
     end
-  
+
     # Should be uninstallable
     describe command('rpm -e greenplum-db-clients') do
       its('exit_status') { should eq 0 }
     end
-  
+
     # Should report uninstalled
     describe command('rpm -q greenplum-db-clients') do
       its('stdout') { should match /package greenplum-db-clients is not installed/ }

--- a/ci/concourse/tests/gpdb6/server/install/controls/gpdb6-server-install.rb
+++ b/ci/concourse/tests/gpdb6/server/install/controls/gpdb6-server-install.rb
@@ -80,6 +80,11 @@ control 'Category:server-installs' do
       its('exit_status') { should eq 0 }
       end
   end
+
+  describe file("/usr/local/greenplum-db/ext/python/lib/python2.7/cmd.pyc") do
+    it { should exist}
+  end
+
 end
 
 control 'Category:server-installs_with_link' do
@@ -87,15 +92,15 @@ control 'Category:server-installs_with_link' do
    impact 1.0
    title 'RPM installs with symbolic link'
    desc 'When the RPM is installed a shorter symbolic link is created and destroyed on uninstall'
-  
+
    describe file('/usr/local/greenplum-db') do
      it { should be_linked_to "/usr/local/greenplum-db-#{gpdb_version}" }
    end
-  
+
 end
-  
+
 control 'Category:server-greenplum_path.sh' do
-  
+
   impact 1.0
   title 'greenplum_path.sh is correct'
   desc 'Modification must be made to the given upstream greenplum_path.sh'
@@ -105,11 +110,11 @@ control 'Category:server-greenplum_path.sh' do
     its('exit_status') { should eq 0 }
     its('stdout') { should eq "/usr/local/greenplum-db-#{gpdb_version}\n" }
   end
-  
+
 end
-  
+
 control 'Category:server-rpm_binary_match' do
-  
+
   impact 1.0
   title 'RPM Binary matches Built Source'
   desc 'The binaries that are packaged in the RPM should match in version to what is expected from the source code'
@@ -184,3 +189,4 @@ control 'RPM is relocateable' do
   end
 
 end
+

--- a/gpdb-deb-test/features/gpdb-client-deb.feature
+++ b/gpdb-deb-test/features/gpdb-client-deb.feature
@@ -7,4 +7,5 @@ Feature: deb install and remove works
   Scenario: gpdb client deb can be removed
     Given gpdb client installed
     When remove gpdb client
-    Then gpdb client removed as expected
+    Then gpdb client link removed as expected
+    And gpdb client removed as expected

--- a/gpdb-deb-test/features/gpdb-deb.feature
+++ b/gpdb-deb-test/features/gpdb-deb.feature
@@ -8,4 +8,5 @@ Feature: deb install and remove works
   Scenario: gpdb server deb can be removed
     Given gpdb installed
     When remove gpdb
-    Then gpdb removed as expected
+    Then gpdb link removed as expected
+    And gpdb removed as expected


### PR DESCRIPTION
Move python bytecode compilation to RPM/DEB package postinstall
    
    - Remove bytecode when exporting gpdb tarball
    - Compile bytecode:
            - As part of RPM install scriptlet
            - As part of DEB postinst scriptlet
    - Remove bytecode when uninstalling packages.
            - Files are registered during RPM install scriptlet, are removed
              during normal uninstall
            - As part of DEB prerm scriptlet
    
    Add package tests