### PR TITLE
Fix the prerm script for gpdb debian package

### DIFF
--- a/ci/concourse/scripts/build-gpdb-clients-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-clients-deb.bash
@@ -31,7 +31,8 @@ EOF
 	cat <<EOF >"${__package_name}/DEBIAN/prerm"
 #!/bin/sh
 set -e
-dpkg -L "${__package_name}" | grep '\.py$' | while read file; do rm -f "${file}"[co] >/dev/null; done
+cd ${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}
+find . -name *.pyc -exec rm -rf {} \;
 exit 0
 EOF
 	chmod 0775 "${__package_name}/DEBIAN/prerm"

--- a/ci/concourse/scripts/build-gpdb-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-deb.bash
@@ -46,7 +46,8 @@ EOF
 	cat <<EOF >"${__package_name}/DEBIAN/prerm"
 #!/bin/sh
 set -e
-dpkg -L "${__package_name}" | grep '\.py$' | while read file; do rm -f "${file}"[co] >/dev/null; done
+cd ${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}
+find . -name *.pyc -exec rm -rf {} \;
 exit 0
 EOF
 	chmod 0775 "${__package_name}/DEBIAN/prerm"


### PR DESCRIPTION
 dpkg -L "${__package_name}" has two errors here:
First __package_name does not have the correct value we want which is greenplum-db-6, actually its value is: greenplum-db-6.17.1+dev.16.g1c70f219d2-ubuntu18.04-amd64
Second, even we give the __package_name the correct value: greenplum-db-6,   dpkg -L "${__package_name}" still will not work, since the *.pyc files are created by the postinst script, debian does not think the .pyc files should belong to debian package,  so it will not any show the *.pyc file.