### PR TITLE
Fix the prerm script for gpdb ppa package

### DIFF
--- a/ci/concourse/oss/ppa.py
+++ b/ci/concourse/oss/ppa.py
@@ -256,5 +256,6 @@ conditions of the subcomponent's license, as noted in the LICENSE file.
     def _prerm(self):
         return Util.strip_margin(
             f'''#!/usr/bin/env bash
-            |dpkg -L {self.package_name} | grep '\.py$' | while read file; do rm -f "${{file}}"[co] >/dev/null;
+            |cd {self.install_location()}
+            |find . -name *.pyc -exec rm -rf {{}} \;
             ''')


### PR DESCRIPTION
dpkg -L {self.package_name} will not show any .pyc file, so use find command to list the pyc files