### PR TITLE
do not block push to tanzunet and push to github release because of v…

### DIFF
--- a/ci/concourse/pipelines/gpdb-opensource-release.yml
+++ b/ci/concourse/pipelines/gpdb-opensource-release.yml
@@ -570,7 +570,6 @@ jobs:
       - rhel7 packaging
       - photon3 packaging
       - ubuntu18.04 packaging
-      - verify ppa release
     - get: gpdb_src
       passed:
       - rhel6 packaging


### PR DESCRIPTION
…erify ppa release

there are times when ppa release is pushed to lauchedpad, but it is in pending state, so the job veriy ppa release is not triggered,
it furture block the github release and tanzunet release.

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>