### PR TITLE
Not set GPHOM when packaging

### DIFF
--- a/ci/concourse/oss/ppa.py
+++ b/ci/concourse/oss/ppa.py
@@ -96,21 +96,10 @@ class SourcePackageBuilder(BasePackageBuilder):
             dest = os.path.join(self.source_dir, 'bin_gpdb')
             tar.extractall(dest)
 
-        self.replace_greenplum_path()
-
         # using _ here is debian convention
         archive_name = f'{self.package_name}_{self.gpdb_upstream_version}.orig.tar.gz'
         with tarfile.open(archive_name, 'w:gz') as tar:
             tar.add(self.source_dir, arcname=os.path.basename(self.source_dir))
-
-    def replace_greenplum_path(self):
-        greenplum_path = os.path.join(self.source_dir, 'bin_gpdb', 'greenplum_path.sh')
-        with fileinput.FileInput(greenplum_path, inplace=True) as file:
-            for line in file:
-                if line.startswith('GPHOME='):
-                    print(f'GPHOME={self.install_location()}')
-                else:
-                    print(line, end='')
 
     def create_debian_dir(self):
         debian_dir = os.path.join(self.source_dir, 'debian')

--- a/ci/concourse/scripts/build-gpdb-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-deb.bash
@@ -128,7 +128,6 @@ EOF
 
 	mkdir -p "${__package_name}/${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}"
 	tar -xf "../${__gpdb_binary_tarbal}" -C "${__package_name}/${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}"
-	sed -i -e "1 s~^\(GPHOME=\).*~\1$GPDB_PREFIX/$GPDB_NAME-$GPDB_VERSION~" "${__package_name}/${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION}/greenplum_path.sh"
 	dpkg-deb --build "${__package_name}"
 	popd
 

--- a/ci/concourse/scripts/greenplum-db-5.spec
+++ b/ci/concourse/scripts/greenplum-db-5.spec
@@ -67,8 +67,6 @@ exit 0
 %post
 if [ ! -e "${RPM_INSTALL_PREFIX}/greenplum-db" ] || [ -L "${RPM_INSTALL_PREFIX}/greenplum-db" ];then
   ln -fsT "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" "${RPM_INSTALL_PREFIX}/greenplum-db" || :
-  # Set GPHOME to the installation prefix
-  sed -i -e "1 s~^\(GPHOME=\).*~\1${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}~" "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}/greenplum_path.sh"
 else
     echo "the expected symlink was not created because a file exists at that location"
 fi

--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -148,8 +148,6 @@ exit 0
 %post
 if [ ! -e "${RPM_INSTALL_PREFIX}/greenplum-db" ] || [ -L "${RPM_INSTALL_PREFIX}/greenplum-db" ];then
   ln -fsT "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" "${RPM_INSTALL_PREFIX}/greenplum-db" || :
-  # Set GPHOME to the installation prefix
-  sed -i -e "1 s~^\(GPHOME=\).*~\1${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}~" "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}/greenplum_path.sh"
 else
   echo "the expected symlink was not created because a file exists at that location"
 fi

--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -141,8 +141,6 @@ exit 0
 %post
 if [ ! -e "${RPM_INSTALL_PREFIX}/greenplum-db" ] || [ -L "${RPM_INSTALL_PREFIX}/greenplum-db" ];then
   ln -fsT "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}" "${RPM_INSTALL_PREFIX}/greenplum-db" || :
-  # Set GPHOME to the installation prefix
-  sed -i -e "1 s~^\(GPHOME=\).*~\1${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}~" "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}/greenplum_path.sh"
 else
   echo "the expected symlink was not created because a file exists at that location"
 fi


### PR DESCRIPTION
That is because GPHOME is determined automatically in gpdb source

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>