### PR TITLE
Create link with full path

### DIFF
--- a/ci/concourse/scripts/build-gpdb-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-deb.bash
@@ -37,7 +37,7 @@ function build_deb() {
 set -e
 cd ${GPDB_PREFIX}/
 rm -f ${GPDB_NAME}
-ln -s ${GPDB_NAME}-${GPDB_VERSION} ${GPDB_NAME}
+ln -s ${GPDB_PREFIX}/${GPDB_NAME}-${GPDB_VERSION} ${GPDB_NAME}
 cd ${GPDB_NAME}-${GPDB_VERSION}
 ext/python/bin/python -m compileall -q -x test .
 exit 0

--- a/gpdb-deb-test/gpdb-deb_test.go
+++ b/gpdb-deb-test/gpdb-deb_test.go
@@ -64,8 +64,8 @@ func gpdbInstalledAsExpected() error {
 	if err != nil {
 		return err
 	}
-	if linkDestination != "greenplum-db-"+gpbdVersion {
-		return fmt.Errorf("/usr/local/greenplum-db links to %s != %s", linkDestination, "greenplum-db-"+gpbdVersion)
+	if linkDestination != filepath.Join("/usr/local", "greenplum-db-"+gpbdVersion) {
+		return fmt.Errorf("/usr/local/greenplum-db links to %s != %s", linkDestination, filepath.Join("/usr/local", "greenplum-db-"+gpbdVersion))
 	}
 	// GPHOME is set
 	gpHome, err := GetEnvFromGreenplumPathFile("/usr/local/greenplum-db/greenplum_path.sh", "GPHOME")


### PR DESCRIPTION
due to https://github.com/greenplum-db/gpdb/commit/b9a2acec5956ab5a2288757d7bc9d8bb52622d8f
when source GPHOME from link, it will show GPHOME=greenplum-db while we expect it
GPHOME=/usr/local/greenplum-db

Co-authored-by: Ning Wu <ningw@vmware.com>
Co-authored-by: Shaoqi Bai <bshaoqi@vmware.com>