### PR TITLE
Remove branch for gpdb_src defination

### DIFF
--- a/ci/concourse/pipelines/gpdb-opensource-release.yml
+++ b/ci/concourse/pipelines/gpdb-opensource-release.yml
@@ -77,8 +77,8 @@ resources:
   type: git
   icon: git
   source:
-    branch: ((gpdb-git-branch))
     uri: ((gpdb-git-remote))
+    fetch_tags: true
     tag_filter: ((gpdb-git-tag-filter))
 
 - name: greenplum-database-release


### PR DESCRIPTION
So git concourse resource can checkout to tags that is not on 6X_STABLE

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>