### PR TITLE
Use github-token-gp-releng instead of gpdb-release-access-token

### DIFF
--- a/ci/concourse/pipelines/gpdb-opensource-release.yml
+++ b/ci/concourse/pipelines/gpdb-opensource-release.yml
@@ -94,7 +94,7 @@ resources:
   source:
     owner: ((gpdb-release-owner))
     repository: ((gpdb-release-repository))
-    access_token: ((gpdb-release-access-token))
+    access_token: ((github-token-gp-releng))
 
 - name: license_file
   type: gcs


### PR DESCRIPTION
Authored-by: Bhanu Kiran Atturu <batturu@vmware.com>