### PR TITLE
Remove yum install for git

### DIFF
--- a/ci/concourse/scripts/verify_gpdb_versions.bash
+++ b/ci/concourse/scripts/verify_gpdb_versions.bash
@@ -20,8 +20,6 @@ assert_postgres_version_matches() {
 	fi
 }
 
-yum -d0 -y install git
-
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel
 
 for bin_gpdb in bin_gpdb_{centos{6,7},ubuntu18.04}; do


### PR DESCRIPTION
This fails in the releng concourse and I dont think we need it.

Authored-by: Karen Huddleston <khuddleston@vmware.com>