### PR TITLE
Fix verify_version step.

### DIFF
--- a/ci/concourse/scripts/verify_gpdb_versions.bash
+++ b/ci/concourse/scripts/verify_gpdb_versions.bash
@@ -22,7 +22,7 @@ assert_postgres_version_matches() {
 
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel
 
-for bin_gpdb in bin_gpdb_{centos{6,7,8},ubuntu18.04}; do
+for bin_gpdb in bin_gpdb_{centos{6,7},ubuntu18.04,rhel8}; do
 	install_greenplum "$bin_gpdb" "${GREENPLUM_INSTALL_DIR}"
 	assert_postgres_version_matches "$GPDB_SRC_SHA" "${GREENPLUM_INSTALL_DIR}"
 done


### PR DESCRIPTION
bin_gpdb_centos8 should be renamed to bin_gpdb_rhel8.

Authored-by: Bhanu Kiran Atturu <batturu@vmware.com>