### PR TITLE
Disalbe _build_id_links

### DIFF
--- a/ci/concourse/scripts/gpdb-7-clients.spec
+++ b/ci/concourse/scripts/gpdb-7-clients.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 %{!?gpdb_clients_name: %define gpdb_clients_name greenplum-db-clients}
 # %%{rpm_gpdb_clients_version} must be supplied or will exit in %%prep
 # %%{gpdb_clients_version} must be supplied or will exit in %%prep

--- a/ci/concourse/scripts/gpdb-clients.spec
+++ b/ci/concourse/scripts/gpdb-clients.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 %{!?gpdb_clients_name: %define gpdb_clients_name greenplum-db-clients}
 # %%{rpm_gpdb_clients_version} must be supplied or will exit in %%prep
 # %%{gpdb_clients_version} must be supplied or will exit in %%prep

--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -10,6 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+%define _build_id_links none
+
 %{!?gpdb_major_version:%global gpdb_major_version 6}
 
 # Disable automatic dependency processing both for requirements and provides

--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -10,6 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+%define _build_id_links none
+
 # Disable automatic dependency processing both for requirements and provides
 AutoReqProv: no
 


### PR DESCRIPTION
install gpdb server rhel8 rpm on gpdb6-rhel8-build image will cause fowllowing errors
Error: Transaction test error file /usr/lib/.build-id/e2/27e93b07fbc71d773fa0bb847faba619639bb4 from install of greenplum-db-6-6.20.0-1.el8.x86_64 conflicts with file from package libquicklz-1.5.0-1.el8.x86_64 file /usr/lib/.build-id/e1/912a5ed956a4243112da62fc86e62cc0176512 from install of greenplum-db-6-6.20.0-1.el8.x86_64 conflicts with file from package libzstd-1.3.7-2.el8.x86_64

So disable build_id_links to bypass the error

[GPR-747]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>