### PR TITLE
Increase test coverage for rhel8.

### DIFF
--- a/ci/concourse/pipelines/gpdb-package-testing.yml
+++ b/ci/concourse/pipelines/gpdb-package-testing.yml
@@ -233,13 +233,13 @@ resources:
     product_slug: vmware-tanzu-greenplum
     product_version: 6\.2\.1
 
-- name: previous-6.12.0-release
+- name: previous-6.20.0-release
   type: tanzunet
   source:
     api_token: ((public-tanzunet-refresh-token))
     endpoint: ((tanzunet-endpoint))
     product_slug: vmware-tanzu-greenplum
-    product_version: 6\.12\.0
+    product_version: 6\.20\.0
 
 - name: previous-6-oss-release
   type: tanzunet
@@ -247,7 +247,7 @@ resources:
     api_token: ((public-tanzunet-refresh-token))
     endpoint: ((tanzunet-endpoint))
     product_slug: greenplum-database
-    product_version: 6\.14\.0
+    product_version: 6\.20\.0
 
 - name: previous-5-release
   type: tanzunet
@@ -468,6 +468,13 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: ((pipeline-name))/rpm_gpdb_centos6/gpdb6/open-source-greenplum-db-6-rhel6-x86_64.rpm
 
+- name: rpm_gpdb6_rhel8_oss
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb6/open-source-greenplum-db-6-rhel8-x86_64.rpm
+
 - name: rpm_gpdb6_centos7
   type: gcs
   source:
@@ -495,6 +502,13 @@ resources:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: ((pipeline-name))/rpm_gpdb_centos7/master/open-source-greenplum-db-7-rhel7-x86_64.rpm
+
+- name: rpm_gpdb7_rhel8_oss
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/master/open-source-greenplum-db-7-rhel8-x86_64.rpm
 
 - name: rpm_gpdb6_rhel8
   type: gcs
@@ -720,7 +734,7 @@ jobs:
     - get: previous-6-release
       params:
         globs: [greenplum-db-*-rhel6-x86_64.rpm]
-    - get: previous-6.12.0-release
+    - get: previous-6.20.0-release
       params:
         globs: [greenplum-db-*-rhel6-x86_64.rpm]
     - get: previous-5-release
@@ -760,7 +774,7 @@ jobs:
     - get: previous-6-release
       params:
         globs: [greenplum-db-*-rhel7-x86_64.rpm]
-    - get: previous-6.12.0-release
+    - get: previous-6.20.0-release
       params:
         globs: [greenplum-db-*-rhel7-x86_64.rpm]
     - get: previous-5-release
@@ -946,6 +960,34 @@ jobs:
       <<: *gpdb6-rpm-params
       PLATFORM: rhel8
   - put: rpm_gpdb6_rhel8
+    params:
+      file: gpdb_rpm_installer/*.rpm
+
+- name: create_gpdb6_rpm_installer_rhel8_oss
+  plan:
+  - in_parallel:
+    - get: greenplum-database-release
+      trigger: true
+    - get: bin_gpdb6_rhel8
+      trigger: true
+    - get: gpdb6-rhel8-build
+    - get: gpdb6-osl
+  - task: retrieve_gpdb6_src
+    file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+    image: gpdb6-rhel8-build
+    input_mapping:
+      bin_gpdb: bin_gpdb6_rhel8
+  - task: build_rpm_gpdb6_rhel8
+    file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+    image: gpdb6-rhel8-build
+    input_mapping:
+      bin_gpdb: bin_gpdb6_rhel8
+      license_file: gpdb6-osl
+    params:
+      <<: *gpdb6-rpm-params-oss
+      PLATFORM: rhel8
+      GPDB_NAME: greenplum-db-6
+  - put: rpm_gpdb6_rhel8_oss
     params:
       file: gpdb_rpm_installer/*.rpm
 
@@ -1146,7 +1188,7 @@ jobs:
       params:
         globs:
         - greenplum-db-*-rhel6-x86_64.rpm
-    - get: previous-6.12.0-release
+    - get: previous-6.20.0-release
       params:
         globs:
         - greenplum-db-*-rhel6-x86_64.rpm
@@ -1231,7 +1273,7 @@ jobs:
       params:
         globs:
         - greenplum-db-*-rhel7-x86_64.rpm
-    - get: previous-6.12.0-release
+    - get: previous-6.20.0-release
       params:
         globs:
         - greenplum-db-*-rhel7-x86_64.rpm
@@ -1321,12 +1363,25 @@ jobs:
       - create_gpdb6_rpm_installer_rhel8
     - get: gpdb6-rhel8-test
     - get: rhel-8
+    - get: previous-6.20.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
+    - get: previous-6-oss-release
+      params:
+        globs:
+        - open-source-greenplum-db-*-rhel8-x86_64.rpm
+    - get: rpm_gpdb6_rhel8_oss
+      passed:
+      - create_gpdb6_rpm_installer_rhel8_oss
+      trigger: true
   - in_parallel:
     - task: test_gpdb6_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
       image: gpdb6-rhel8-test
       input_mapping:
         gpdb_rpm_installer: rpm_gpdb6_rhel8
+        gpdb_rpm_oss_installer: rpm_gpdb6_rhel8_oss
       params:
         PLATFORM: rhel8
         GPDB_MAJOR_VERSION: "6"
@@ -1520,7 +1575,7 @@ jobs:
     image: gpdb7-centos7-build
     input_mapping:
       bin_gpdb: bin_gpdb7_centos7
-  - task: build_rpm_gpdb6_centos7
+  - task: build_rpm_gpdb7_centos7
     file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
     image: gpdb7-centos7-build
     input_mapping:
@@ -1531,6 +1586,34 @@ jobs:
       PLATFORM: rhel7
       GPDB_NAME: greenplum-db-7
   - put: rpm_gpdb7_centos7_oss
+    params:
+      file: gpdb_rpm_installer/*.rpm
+
+- name: create_gpdb7_rpm_installer_rhel8_oss
+  plan:
+  - in_parallel:
+    - get: greenplum-database-release
+      trigger: true
+    - get: bin_gpdb7_rhel8
+      trigger: true
+    - get: gpdb7-rhel8-build
+    - get: gpdb6-osl
+  - task: retrieve_gpdb7_src
+    file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+    image: gpdb7-rhel8-build
+    input_mapping:
+      bin_gpdb: bin_gpdb7_rhel8
+  - task: build_rpm_gpdb7_rhel8
+    file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+    image: gpdb7-rhel8-build
+    input_mapping:
+      bin_gpdb: bin_gpdb7_rhel8
+      license_file: gpdb6-osl
+    params:
+      <<: *gpdb7-rpm-params-oss
+      PLATFORM: rhel8
+      GPDB_NAME: greenplum-db-7
+  - put: rpm_gpdb7_rhel8_oss
     params:
       file: gpdb_rpm_installer/*.rpm
 
@@ -1653,7 +1736,7 @@ jobs:
 - name: test_functionality_gpdb7_rpm_centos7
   plan:
   - in_parallel:
-    - get: previous-6.12.0-release
+    - get: previous-6.20.0-release
       params:
         globs:
         - greenplum-db-*-rhel7-x86_64.rpm
@@ -1792,12 +1875,25 @@ jobs:
       - create_gpdb7_rpm_installer_rhel8
     - get: gpdb7-rhel8-test
     - get: rhel-8
+    - get: previous-6-oss-release
+      params:
+        globs:
+        - open-source-greenplum-db-*-rhel8-x86_64.rpm
+    - get: rpm_gpdb7_rhel8_oss
+      passed:
+      - create_gpdb7_rpm_installer_rhel8_oss
+      trigger: true
+    - get: previous-6.20.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
   - in_parallel:
     - task: test_gpdb7_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
       image: gpdb7-rhel8-test
       input_mapping:
         gpdb_rpm_installer: rpm_gpdb7_rhel8
+        gpdb_rpm_oss_installer: rpm_gpdb7_rhel8_oss
       params:
         PLATFORM: rhel8
         GPDB_MAJOR_VERSION: "7"
@@ -1824,6 +1920,9 @@ jobs:
       passed:
       - create_gpdb7_clients_rpm_installer_rhel8
     - get: rhel-8
+    - get: rpm_gpdb7_rhel8_oss
+      passed:
+      - create_gpdb7_rpm_installer_rhel8_oss
   - in_parallel:
     - task: test_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
@@ -1890,6 +1989,8 @@ groups:
   - test_functionality_clients_gpdb7_deb_ubuntu18.04
   - create_gpdb7_rpm_installer_rhel8
   - test_functionality_gpdb7_rpm_rhel8
+  - create_gpdb6_rpm_installer_rhel8_oss
+  - create_gpdb7_rpm_installer_rhel8_oss
   name: All
 - jobs:
   - create_gpdb5_rpm_installer_sles11
@@ -1913,6 +2014,7 @@ groups:
   - create_gpdb6_rpm_installer_centos6_oss
   - create_gpdb6_rpm_installer_centos7_oss
   - create_gpdb6_deb_ppa_installer_ubuntu18.04
+  - create_gpdb6_rpm_installer_rhel8_oss
   name: gpdb 6 server
 - jobs:
   - create_gpdb6_clients_rpm_installer_sles12
@@ -1934,6 +2036,7 @@ groups:
   - create_gpdb7_rpm_installer_centos7_oss
   - create_gpdb7_rpm_installer_rhel8
   - test_functionality_gpdb7_rpm_rhel8
+  - create_gpdb7_rpm_installer_rhel8_oss
   name: gpdb 7 server
 - jobs:
   - create_gpdb7_clients_rpm_installer_centos7

--- a/ci/concourse/scripts/test-functionality-rpm.bash
+++ b/ci/concourse/scripts/test-functionality-rpm.bash
@@ -47,23 +47,13 @@ if [[ $GPDB_MAJOR_VERSION == "5" ]]; then
 	fi
 elif [[ $GPDB_MAJOR_VERSION == "6" ]]; then
 	export RPM_GPDB_VERSION="$(rpm --query --info --package ${GPDB_RPM_PATH}/greenplum-db-6-"${GPDB_RPM_ARCH}"-x86_64.rpm | awk '/Version/{printf "%s", $3}')"
-	if [[ $PLATFORM == "rhel6" || $PLATFORM == "rhel7" ]]; then
+	if [[ $PLATFORM == "rhel6" || $PLATFORM == "rhel7" || $PLATFORM == "rhel8" ]]; then
 		curl https://omnitruck.chef.io/install.sh | bash -s -- -P inspec -v 3
 		test_prefix='greenplum-database-release/ci/concourse/tests/gpdb6/server'
 		inspec exec ${test_prefix}/conflicts --reporter documentation --no-distinct-exit --no-backend-cache
 		inspec exec ${test_prefix}/install --reporter documentation --no-distinct-exit --no-backend-cache
 		inspec exec ${test_prefix}/remove --reporter documentation --no-backend-cache
 		inspec exec ${test_prefix}/upgrade --reporter documentation --no-distinct-exit --no-backend-cache
-
-	elif [[ $PLATFORM == "rhel8" ]]; then
-		curl https://omnitruck.chef.io/install.sh | bash -s -- -P inspec -v 3
-		test_prefix='greenplum-database-release/ci/concourse/tests/gpdb6/server'
-		#TODO add conflicts test when rhel8 has oss release
-		#inspec exec ${test_prefix}/conflicts --reporter documentation --no-distinct-exit --no-backend-cache
-		inspec exec ${test_prefix}/install --reporter documentation --no-distinct-exit --no-backend-cache
-		inspec exec ${test_prefix}/remove --reporter documentation --no-backend-cache
-		#TODO add upgrade test when rhel8 released to tanzunet
-		#inspec exec ${test_prefix}/upgrade --reporter documentation --no-distinct-exit --no-backend-cache
 
 	elif [[ $PLATFORM == "photon"* ]]; then
 		wget https://packages.chef.io/files/stable/inspec/3.9.3/el/7/inspec-3.9.3-1.el7.x86_64.rpm
@@ -79,22 +69,13 @@ elif [[ $GPDB_MAJOR_VERSION == "6" ]]; then
 	fi
 elif [[ $GPDB_MAJOR_VERSION == "7" ]]; then
 	export RPM_GPDB_VERSION="$(rpm --query --info --package ${GPDB_RPM_PATH}/greenplum-db-7-"${GPDB_RPM_ARCH}"-x86_64.rpm | awk '/Version/{printf "%s", $3}')"
-	if [[ $PLATFORM == "rhel7" ]]; then
+	if [[ $PLATFORM == "rhel7" || $PLATFORM == "rhel8" ]]; then
 		curl https://omnitruck.chef.io/install.sh | bash -s -- -P inspec -v 3
 		test_prefix='greenplum-database-release/ci/concourse/tests/gpdb7/server'
 		inspec exec ${test_prefix}/conflicts --reporter documentation --no-distinct-exit --no-backend-cache
 		inspec exec ${test_prefix}/install --reporter documentation --no-distinct-exit --no-backend-cache
 		inspec exec ${test_prefix}/remove --reporter documentation --no-backend-cache
 		inspec exec ${test_prefix}/upgrade --reporter documentation --no-distinct-exit --no-backend-cache
-	elif [[ $PLATFORM == "rhel8" ]]; then
-		curl https://omnitruck.chef.io/install.sh | bash -s -- -P inspec -v 3
-		test_prefix='greenplum-database-release/ci/concourse/tests/gpdb7/server'
-		#TODO add conflicts test when rhel8 has oss release
-		#inspec exec ${test_prefix}/conflicts --reporter documentation --no-distinct-exit --no-backend-cache
-		inspec exec ${test_prefix}/install --reporter documentation --no-distinct-exit --no-backend-cache
-		inspec exec ${test_prefix}/remove --reporter documentation --no-backend-cache
-		#TODO add upgrade test when rhel8 released to tanzunet
-		#inspec exec ${test_prefix}/upgrade --reporter documentation --no-distinct-exit --no-backend-cache
 	else
 		echo "${PLATFORM} is not yet supported for Greenplum 7.X"
 		exit 1

--- a/ci/concourse/tasks/test-functionality-rpm.yml
+++ b/ci/concourse/tasks/test-functionality-rpm.yml
@@ -12,7 +12,7 @@ inputs:
   optional: true
 - name: previous-6-release
   optional: true
-- name: previous-6.12.0-release
+- name: previous-6.20.0-release
   optional: true
 - name: previous-6-oss-release
   optional: true

--- a/ci/concourse/tests/gpdb6/server/conflicts/gpdb6-server-conflicts.rb
+++ b/ci/concourse/tests/gpdb6/server/conflicts/gpdb6-server-conflicts.rb
@@ -10,7 +10,7 @@ gpdb_rpm_oss_path = ENV['GPDB_RPM_OSS_PATH']
 gpdb_rpm_arch = ENV['GPDB_RPM_ARCH']
 
 
-previous_version = File.read('previous-6.12.0-release/version').split('#').first if File.exist?('previous-6.12.0-release/version')
+previous_version = File.read('previous-6.20.0-release/version').split('#').first if File.exist?('previous-6.20.0-release/version')
 previous_oss_version = File.read('previous-6-oss-release/version').split('#').first if File.exist?('previous-6-oss-release/version')
 
 
@@ -24,6 +24,7 @@ rpm_gpdb_version = `#{rpm_query("Version", rpm_full_path)}`
 
 control 'Category:server-conflict_enterprise_to_oss_same_version' do
   # Previous 6 release not yet available for Photon
+  version = os.release
   if os.redhat?
 
     title "Install VTGP (Enterprise) first and GPDBVT (OSS) second for same version."
@@ -34,8 +35,14 @@ control 'Category:server-conflict_enterprise_to_oss_same_version' do
     end
     describe command("yum install -y -q #{rpm_oss_full_path}") do
       its('exit_status') {should eq 1}
-      its('stderr') { should match /Error: greenplum-db-6 conflicts with open-source-greenplum-db-6*/ }
-      its('stderr') { should match /Error: open-source-greenplum-db-6 conflicts with greenplum-db-6*/ }
+      if version =~ /8/
+        # Error message for rhel8 is different from centos 6 and 7
+        its('stderr') { should match /greenplum-db-6-.* conflicts with open-source-greenplum-db-6*/ }
+        its('stderr') { should match /open-source-greenplum-db-6-.* conflicts with greenplum-db-6*/ }
+      else
+        its('stderr') { should match /Error: greenplum-db-6 conflicts with open-source-greenplum-db-6*/ }
+        its('stderr') { should match /Error: open-source-greenplum-db-6 conflicts with greenplum-db-6*/ }
+      end
     end
     describe command("yum remove -y #{rpm_gpdb_name}") do
       its('exit_status') {should eq 0}
@@ -43,13 +50,18 @@ control 'Category:server-conflict_enterprise_to_oss_same_version' do
 
     title "Install VTGP (Enterprise) first and GPDBVT (OSS) second for different version."
 
-    describe command("yum install -y previous-6.12.0-release/greenplum-db-#{previous_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
+    describe command("yum install -y previous-6.20.0-release/greenplum-db-#{previous_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
     its('exit_status') {should eq 0}
     its('stdout') { should match /greenplum-db-6*/ }
     end
     describe command("yum install -y -q #{rpm_oss_full_path}") do
     its('exit_status') {should eq 1}
-    its('stderr') { should match /Error: open-source-greenplum-db-6 conflicts with greenplum-db-6*/ }
+    if version =~ /8/
+      # Error message for rhel8 is different from centos 6 and 7
+      its('stderr') { should match /open-source-greenplum-db-6-.* conflicts with greenplum-db-6*/ }
+    else
+      its('stderr') { should match /Error: open-source-greenplum-db-6 conflicts with greenplum-db-6*/ }
+    end
     end
     describe command("yum remove -y #{rpm_gpdb_name}") do
     its('exit_status') {should eq 0}
@@ -65,8 +77,14 @@ control 'Category:server-conflict_enterprise_to_oss_same_version' do
 
     describe command("yum install -y -q #{rpm_full_path}") do
     its('exit_status') {should eq 1}
-    its('stderr') { should match /Error: greenplum-db-6 conflicts with open-source-greenplum-db-6*/ }
-    its('stderr') { should match /Error: open-source-greenplum-db-6 conflicts with greenplum-db-6*/ }
+    if version =~ /8/
+      # Error message for rhel8 is different from centos 6 and 7
+      its('stderr') { should match /greenplum-db-6-.* conflicts with open-source-greenplum-db-6*/ }
+      its('stderr') { should match /open-source-greenplum-db-6-.* conflicts with greenplum-db-6*/ }
+    else
+      its('stderr') { should match /Error: greenplum-db-6 conflicts with open-source-greenplum-db-6*/ }
+      its('stderr') { should match /Error: open-source-greenplum-db-6 conflicts with greenplum-db-6*/ }
+    end
     end
 
     describe command("yum remove -y #{rpm_gpdb_oss_name}") do
@@ -82,7 +100,12 @@ control 'Category:server-conflict_enterprise_to_oss_same_version' do
 
     describe command("yum install -y -q #{rpm_full_path}") do
     its('exit_status') {should eq 1}
-    its('stderr') { should match /Error: greenplum-db-6 conflicts with open-source-greenplum-db-6*/ }
+    if version =~ /8/
+      # Error message for rhel8 is different from centos 6 and 7
+      its('stderr') { should match /greenplum-db-6-.* conflicts with open-source-greenplum-db-6*/ }
+    else
+      its('stderr') { should match /Error: greenplum-db-6 conflicts with open-source-greenplum-db-6*/ }
+    end
     end
 
     describe command("yum remove -y #{rpm_gpdb_oss_name}") do

--- a/ci/concourse/tests/gpdb6/server/upgrade/controls/gpdb6-server-upgrade.rb
+++ b/ci/concourse/tests/gpdb6/server/upgrade/controls/gpdb6-server-upgrade.rb
@@ -23,18 +23,18 @@ previous_5_version = File.read('previous-5-release/version').split('#').first if
 control 'Category:server-rpm_is_upgradable' do
   # Previous 6 release not yet available for Photon
   if os.redhat?
-    describe command("rpm --install previous-6.12.0-release/greenplum-db-6.12.0-#{gpdb_rpm_arch}-x86_64.rpm") do
+    describe command("rpm --install previous-6.20.0-release/greenplum-db-6.20.0-#{gpdb_rpm_arch}-x86_64.rpm") do
       its('exit_status') { should eq 0 }
     end
 
     describe command("rpm --query greenplum-db-6") do
-      its('stdout') { should match /greenplum-db-6-6.12.0*/ }
+      its('stdout') { should match /greenplum-db-6-6.20.0*/ }
       its('exit_status') { should eq 0 }
     end
 
     describe file("/usr/local/greenplum-db") do
       it { should be_symlink }
-      its('link_path') { should eq "/usr/local/greenplum-db-6.12.0" }
+      its('link_path') { should eq "/usr/local/greenplum-db-6.20.0" }
     end
 
     describe command("rpm --upgrade #{rpm_full_path}") do
@@ -60,8 +60,8 @@ end
 control 'RPM obsoletes GPDB 6' do
 
   title 'when both greenplum-db version 6.2.1 and greenplum-db-6 are installed.'
-  # Previous 6 release not yet available for Photon
-  if os.redhat?
+  # Previous 6 release not yet available for Photon and rhel8
+  if os.redhat? and os.release !~ /8/
     describe command("yum install -y previous-6-release/greenplum-db-#{previous_6_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
       its('exit_status') { should eq 0 }
     end
@@ -105,8 +105,8 @@ end
 control 'RPM with GPDB 5' do
 
   title 'when both greenplum-db version 5.2.1 and greenplum-db-6 are installed.'
-  # Previous 6 release not yet available for Photon
-  if os.redhat?
+  # Previous 6 release not yet available for Photon and rhel8
+  if os.redhat? and os.release !~ /8/
     describe command("yum install -y previous-5-release/greenplum-db-#{previous_5_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
       its('exit_status') { should eq 0 }
     end

--- a/ci/concourse/tests/gpdb7/server/conflicts/gpdb7-server-conflicts.rb
+++ b/ci/concourse/tests/gpdb7/server/conflicts/gpdb7-server-conflicts.rb
@@ -18,6 +18,7 @@ rpm_full_path = "#{gpdb_rpm_path}/#{rpm_gpdb_name}-#{gpdb_rpm_arch}-x86_64.rpm"
 rpm_gpdb_version = `#{rpm_query("Version", rpm_full_path)}`
 
 control 'Category:server-conflict_enterprise_to_oss_same_version' do
+  version = os.release
   if os.redhat?
 
     title "Install VTGP (Enterprise) first and GPDBVT (OSS) second for same version."
@@ -28,8 +29,14 @@ control 'Category:server-conflict_enterprise_to_oss_same_version' do
     end
     describe command("yum install -y -q #{rpm_oss_full_path}") do
       its('exit_status') {should eq 1}
-      its('stderr') { should match /Error: greenplum-db-7 conflicts with open-source-greenplum-db-7*/ }
-      its('stderr') { should match /Error: open-source-greenplum-db-7 conflicts with greenplum-db-7*/ }
+      if version =~ /8/
+        # Error message for rhel8 is different from centos 6 and 7
+        its('stderr') { should match /greenplum-db-7-.* conflicts with open-source-greenplum-db-7*/ }
+        its('stderr') { should match /open-source-greenplum-db-7-.* conflicts with greenplum-db-7*/ }
+      else
+        its('stderr') { should match /Error: greenplum-db-7 conflicts with open-source-greenplum-db-7*/ }
+        its('stderr') { should match /Error: open-source-greenplum-db-7 conflicts with greenplum-db-7*/ }
+      end
     end
     describe command("yum remove -y #{rpm_gpdb_name}") do
       its('exit_status') {should eq 0}
@@ -45,8 +52,14 @@ control 'Category:server-conflict_enterprise_to_oss_same_version' do
 
     describe command("yum install -y -q #{rpm_full_path}") do
     its('exit_status') {should eq 1}
-    its('stderr') { should match /Error: greenplum-db-7 conflicts with open-source-greenplum-db-7*/ }
-    its('stderr') { should match /Error: open-source-greenplum-db-7 conflicts with greenplum-db-7*/ }
+    if version =~ /8/
+      # Error message for rhel8 is different from centos 6 and 7
+      its('stderr') { should match /greenplum-db-7-.* conflicts with open-source-greenplum-db-7*/ }
+      its('stderr') { should match /open-source-greenplum-db-7-.* conflicts with greenplum-db-7*/ }
+    else
+      its('stderr') { should match /Error: greenplum-db-7 conflicts with open-source-greenplum-db-7*/ }
+      its('stderr') { should match /Error: open-source-greenplum-db-7 conflicts with greenplum-db-7*/ }
+    end
     end
 
     describe command("yum remove -y #{rpm_gpdb_oss_name}") do

--- a/ci/concourse/tests/gpdb7/server/upgrade/controls/gpdb7-server-upgrade.rb
+++ b/ci/concourse/tests/gpdb7/server/upgrade/controls/gpdb7-server-upgrade.rb
@@ -17,14 +17,14 @@ rpm_gpdb_version = `#{rpm_query("Version", rpm_full_path)}`
 # for RPMs `-` is an invalid character for the version string
 # when the RPM was built, any `-` was converted to `_`
 gpdb_version = rpm_gpdb_version.sub("_", "-") if rpm_gpdb_version != nil
-previous_6_version = File.read('previous-6.12.0-release/version').split('#').first if File.exist?('previous-6.12.0-release/version')
+previous_6_version = File.read('previous-6.20.0-release/version').split('#').first if File.exist?('previous-6.20.0-release/version')
 
 control 'RPM with GPDB 6' do
 
-  title 'when both greenplum-db version 6.12.0 and greenplum-db-7 are installed.'
+  title 'when both greenplum-db version 6.20.0 and greenplum-db-7 are installed.'
   # Previous 6 release not yet available for Photon
   if os.redhat?
-    describe command("yum install -y previous-6.12.0-release/greenplum-db-#{previous_6_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
+    describe command("yum install -y previous-6.20.0-release/greenplum-db-#{previous_6_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
       its('exit_status') { should eq 0 }
     end
 


### PR DESCRIPTION
Change previous 6.12.0 to 6.20.0 since that's the oldest release with rhel8 rpm on TanzuNet.

[GPR-748]

Authored-by: Bhanu Kiran Atturu <batturu@vmware.com>