### PR TITLE
Don't compile python3.9 scripts when packaging rpm.

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -137,7 +137,7 @@ fi
 mkdir -p %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 cp -R * %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
 pushd %{buildroot}/%{prefix}/greenplum-db-%{gpdb_version}
-ext/python/bin/python -m compileall -q -x test .
+ext/python/bin/python -m compileall -q -x "(test|python3\.9)" .
 popd
 # Disable build root policy trying to generate %.pyo/%.pyc
 exit 0


### PR DESCRIPTION
In 6.22 release, we introduce python39 to Greenplum. When packing the rpm package, we compiling python scripts to .pyc bytecode files. However, the compilation steps is using a python2 interpreter which is unable to compile python3.9 scripts. On the other hand, python3.9 scripts have been compiled to bytecode files, we don't need to compile them again.

Co-authored-by: Hao Zhang <hzhang2@vmware.com>
Co-authored-by: Xing Guo <higuoxing@gmail.com>