### PR TITLE
Fix post installation script for debian package (Temporarily).

### DIFF
--- a/ci/concourse/scripts/build-gpdb-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-deb.bash
@@ -119,7 +119,7 @@ EOF
 #!/bin/sh
 set -e
 cd /opt/greenplum-db-${GPDB_VERSION}
-ext/python/bin/python -m compileall -q -x test .
+ext/python/bin/python -m compileall -q -x "(test|python3)" .
 exit 0
 EOF
 		chmod 0775 "${__package_name}/${DEB_DIR}/postinst"
@@ -148,7 +148,7 @@ cd ${GPDB_NAME}-${GPDB_VERSION}
 if [ "${gpdb_major_version}" = "7" ]; then
 	python3 -m compileall -q -x test .
 else
-	ext/python/bin/python -m compileall -q -x test .
+	ext/python/bin/python -m compileall -q -x "(test|python3)" .
 fi
 exit 0
 EOF


### PR DESCRIPTION
We ship Python 3.9 with Greenplum database to enterprise users. We encountered errors when compiling Python 3.9 scripts during post installation. Actually, we don't want to compile them in this release. This patch fixes the issue temporarily, we need to re-consider how to integrate Python 3.9 better in future release.