### PR TITLE
Fix PYTHONHOME to correct location

### DIFF
--- a/ci/concourse/scripts/compile-gpdb-oss.bash
+++ b/ci/concourse/scripts/compile-gpdb-oss.bash
@@ -26,10 +26,12 @@ generate_build_number() {
 install_python() {
 	echo "Installing python"
 	# shellcheck disable=SC2155
-	export PYTHONHOME=$(find /opt -maxdepth 1 -type d -name "python*")
+	export PYTHONHOME=$(find /opt -maxdepth 1 -type d -name "python-2*")
 	export PATH="${PYTHONHOME}/bin:${PATH}"
 	echo "${PYTHONHOME}/lib" >>/etc/ld.so.conf.d/gpdb.conf
 	ldconfig
+	export PYTHONHOME39=$(find /opt -maxdepth 1 -type d -name "python-3.9.*")
+	export PATH="${PYTHONHOME39}/bin:${PATH}"
 }
 
 build_gpdb() {


### PR DESCRIPTION
Since we integrate python3.9 to gpdb6 and the build image for rhel8/centos7/ubuntu18.04 will include two version python, we need to use correct command to get the PYTHONHOME.

[GPR-1035]

Co-authored-by: Hao Zhang <hzhang2@vmware.com>
Co-authored-by: Ning Wu <ningw@vmware.com>