### PR TITLE
Rhel8, rocky8,oracle linux8 need xerces-c

### DIFF
--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -55,6 +55,7 @@ Requires: tar
 Requires: which
 Requires: zip
 Requires: zlib
+Requires: xerces-c
 %endif
 
 %if "%{platform}" == "rhel8"

--- a/ci/concourse/scripts/test-package-dependencies.bash
+++ b/ci/concourse/scripts/test-package-dependencies.bash
@@ -19,6 +19,7 @@ if [[ $PLATFORM == "rhel"* ]]; then
 		subscription-manager attach --auto
 		# Required to install *-devel pacakges.
 		subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 	fi
 
 	# Install file command


### PR DESCRIPTION
Since we do not vendor xerces-c, so user need to install xerces-c

[GPR-1013]

Co-authored-by: Lucas Bonner <blucas@vmware.com>
Co-authored-by: Shaoqi Bai <bshaoqi@vmware.com>