### PR TITLE
Subscription manager fix for gpdb-package-testing

### DIFF
--- a/ci/concourse/scripts/test-package-dependencies.bash
+++ b/ci/concourse/scripts/test-package-dependencies.bash
@@ -15,6 +15,7 @@ if [[ $PLATFORM == "rhel"* || $PLATFORM == "rocky"* ]]; then
 
 	if [[ $PLATFORM == "rhel8" ]]; then
 		dnf update -y && dnf install -y subscription-manager
+		rm /etc/rhsm-host
 		subscription-manager register --org=${REDHAT_SUBSCRIPTION_ORG_ID} --activationkey=${REDHAT_SUBSCRIPTION_KEY_ID}
 		subscription-manager attach --auto
 		# Required to install *-devel pacakges.


### PR DESCRIPTION
Adds a command to remove /etc/rhsm-host for rhel8 in order to bypass the subscription manager failure in the container

[GPR-1101]

Co-authored-by: Shaoqi Bai <bshaoqi@vmware.com>
Co-authored-by: Lucas Bonner <blucas@vmware.com>