### PR TITLE
Proposed fix to the dev pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ set-gpdb-package-testing-prod: generate-variables
 
 .PHONY: set-gpdb-package-testing-dev
 set-gpdb-package-testing-dev: generate-variables
-	sed -e 's|/env|/dev|g' ci/concourse/pipelines/gpdb-package-testing.yml > ci/concourse/pipelines/gpdb-package-testing-dev.yml
+	sed -e 's|/env|/dev|g' ci/concourse/pipelines/gpdb-package-testing-devel.yml > ci/concourse/pipelines/gpdb-package-testing-dev.yml
 
 	$(FLY_CMD) --target=$(CONCOURSE) \
 	set-pipeline \

--- a/ci/concourse/pipelines/gpdb-package-testing-devel.yml
+++ b/ci/concourse/pipelines/gpdb-package-testing-devel.yml
@@ -1,0 +1,2217 @@
+---
+## ======================================================================
+##                                           _
+##  _ __ ___  ___  ___  _   _ _ __ ___ ___  | |_ _   _ _ __   ___  ___
+## | '__/ _ \/ __|/ _ \| | | | '__/ __/ _ \ | __| | | | '_ \ / _ \/ __|
+## | | |  __/\__ \ (_) | |_| | | | (_|  __/ | |_| |_| | |_) |  __/\__ \
+## |_|  \___||___/\___/ \__,_|_|  \___\___|  \__|\__, | .__/ \___||___/
+##                                               |___/|_|
+## ======================================================================
+resource_types:
+  - name: tanzunet
+    type: registry-image
+    source:
+      repository: pivotalcf/pivnet-resource
+      tag: latest-final
+
+  - name: gcs
+    type: registry-image
+    source:
+      repository: frodenas/gcs-resource
+
+## ======================================================================
+##  _ __ ___  ___  ___  _   _ _ __ ___ ___  ___
+## | '__/ _ \/ __|/ _ \| | | | '__/ __/ _ \/ __|
+## | | |  __/\__ \ (_) | |_| | | | (_|  __/\__ \
+## |_|  \___||___/\___/ \__,_|_|  \___\___||___/
+## ======================================================================
+resources:
+  - name: greenplum-database-release
+    type: git
+    source:
+      branch: ((greenplum-database-release-git-branch))
+      uri: ((greenplum-database-release-git-remote))
+
+  - name: gp-release
+    source:
+      branch: main
+      private_key: ((gp-release-deploy-key))
+      uri: git@github.com:pivotal/gp-release
+    type: git
+
+  - name: gp-release-train
+    type: git
+    source:
+      uri: git@github.com:pivotal/gp-release-train.git
+      paths:
+        - consist/6.99.99.toml
+      branch: main
+      private_key: ((releng/gp-release-train-deploy-key))
+
+  - name: gp-greenplum-morgan-stanley
+    source:
+      branch: main
+      private_key: ((releng/gp-greenplum-morgan-stanley-deploy-key))
+      uri: git@github.com:pivotal/gp-greenplum-morgan-stanley.git
+    type: git
+
+  - name: google-cloud-build
+    source:
+      repository: gcr.io/data-gpdb-public-images/google-cloud-build
+      tag: latest
+    type: registry-image
+
+  - name: start-release-process
+    source:
+      repository: gcr.io/data-gpdb-public-images/start-release-process
+      tag: dev
+    type: registry-image
+
+  - name: centos-gpdb-dev-6
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb5-centos6-build-test
+      tag: 'latest'
+
+  - name: centos-gpdb-dev-7
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test
+      tag: 'latest'
+
+  - name: centos-6
+    type: registry-image
+    source:
+      repository: centos
+      tag: '6'
+
+  - name: centos-7
+    type: registry-image
+    source:
+      repository: centos
+      tag: '7'
+
+  - name: ubuntu-18.04
+    type: registry-image
+    source:
+      repository: ubuntu
+      tag: '18.04'
+
+  - name: gpdb5-sles11-build-test
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb5-sles11-build-test
+      tag: latest
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+    type: registry-image
+
+  - name: bin_gpdb5_centos6
+    type: s3
+    source:
+      access_key_id: ((aws-bucket-access-key-id))
+      secret_access_key: ((aws-bucket-secret-access-key))
+      region_name: ((aws-region))
+      bucket: gpdb-stable-concourse-builds
+      versioned_file: release_candidates/bin_gpdb_centos6/gpdb5/bin_gpdb.tar.gz
+
+  - name: rpm_gpdb5_centos6
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_centos6/gpdb5/greenplum-db-5-rhel6-x86_64.rpm
+
+  - name: bin_gpdb5_centos7
+    type: s3
+    source:
+      access_key_id: ((aws-bucket-access-key-id))
+      secret_access_key: ((aws-bucket-secret-access-key))
+      region_name: ((aws-region))
+      bucket: gpdb-stable-concourse-builds
+      versioned_file: release_candidates/bin_gpdb_centos7/gpdb5/bin_gpdb.tar.gz
+
+  - name: bin_gpdb6_clients_centos6
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/gpdb6/clients-rc-(.*)-rhel6_x86_64.tar.gz
+
+  - name: bin_gpdb6_clients_centos7
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/gpdb6/clients-rc-(.*)-rhel7_x86_64.tar.gz
+
+  - name: bin_gpdb6_clients_rhel8
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/gpdb6/clients-rc-(.*)-rhel8_x86_64.tar.gz
+
+
+  - name: bin_gpdb6_clients_ubuntu18.04
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/gpdb6/clients-rc-(.*)-ubuntu18.04_x86_64.tar.gz
+
+  - name: bin_gpdb6_clients_sles12
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/gpdb6/clients-rc-(.*)-sles12_x86_64.tar.gz
+
+  - name: bin_gpdb7_clients_rhel8
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/master/clients-rc-(.*)-rhel8_x86_64.tar.gz
+
+  - name: bin_gpdb7_clients_rocky8
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: clients/published/main/clients-rc-(.*)-rocky8_x86_64.tar.gz
+
+  - name: rpm_gpdb5_centos7
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_centos7/gpdb5/greenplum-db-5-rhel7-x86_64.rpm
+
+  - name: bin_gpdb5_sles11
+    type: s3
+    source:
+      access_key_id: ((aws-bucket-access-key-id))
+      secret_access_key: ((aws-bucket-secret-access-key))
+      region_name: ((aws-region))
+      bucket: gpdb-stable-concourse-builds
+      versioned_file: release_candidates/bin_gpdb_sles11/gpdb5/bin_gpdb.tar.gz
+
+  - name: bin_gpdb6_ubuntu18.04_for_ppa
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: oss/release-candidates/gpdb6/greenplum-db-ppa-(.*)-ubuntu18.04.tar.gz
+
+  - name: rpm_gpdb5_sles11
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_sles11/gpdb5/greenplum-db-5-sles11-x86_64.rpm
+
+  - name: rpm_gpdb6_clients_centos6
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_clients_centos6/gpdb6/greenplum-db-clients-0.0.0-rhel6-x86_64.rpm
+
+  - name: rpm_gpdb6_clients_centos7
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_clients_centos7/gpdb6/greenplum-db-clients-0.0.0-rhel7-x86_64.rpm
+
+  - name: rpm_gpdb6_clients_rhel8
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_clients_rhel8/gpdb6/greenplum-db-clients-0.0.0-rhel8-x86_64.rpm
+
+  - name: rpm_gpdb7_clients_rhel8
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_clients_rhel8/master/greenplum-db-clients-0.0.0-rhel8-x86_64.rpm
+
+  - name: rpm_gpdb7_clients_rocky8
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_clients_rocky8/main/greenplum-db-clients-0.0.0-rocky8-x86_64.rpm
+
+  - name: rpm_gpdb6_clients_sles12
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_clients_sles12/gpdb6/greenplum-db-clients-0.0.0-sles12-x86_64.rpm
+
+  - name: previous-6-release
+    type: tanzunet
+    source:
+      api_token: ((releng/public-tanzunet-refresh-token))
+      endpoint: ((tanzunet-endpoint))
+      product_slug: vmware-tanzu-greenplum
+      product_version: 6\.2\.1
+
+  - name: previous-6.20.0-release
+    type: tanzunet
+    source:
+      api_token: ((releng/public-tanzunet-refresh-token))
+      endpoint: ((tanzunet-endpoint))
+      product_slug: vmware-tanzu-greenplum
+      product_version: 6\.20\.0
+
+  # the file is comming from https://concourse.releng.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release/jobs/publish_to_ppa/builds/11
+  # it is 6.21.2 ppa deb package, manully updloaded to the following command
+  # yamllint disable-line rule:line-length
+  # gsutil cp gs://greenplum-database-concourse-resources-intermediates-prod/greenplum-database-release/deb_gpdb6_ppa_ubuntu18.04/greenplum-db-6-ubuntu18.04-amd64.deb#1661554503065107 gs://greenplum-database-concourse-resources-prod/deb_gpdb6_ppa_ubuntu18.04/released/gpdb6/greenplum-db-6.21.2-ubuntu18.04-amd64.deb
+  - name: previous_gpdb_deb_ppa_installer
+    type: gcs
+    source:
+      bucket: greenplum-database-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: deb_gpdb6_ppa_ubuntu18.04/released/gpdb6/greenplum-db-(6.21.*)-ubuntu18.04-amd64.deb
+
+  - name: previous-6-oss-release
+    type: tanzunet
+    source:
+      api_token: ((releng/public-tanzunet-refresh-token))
+      endpoint: ((tanzunet-endpoint))
+      product_slug: greenplum-database
+      product_version: 6\.20\.0
+
+  - name: previous-5-release
+    type: tanzunet
+    source:
+      api_token: ((releng/public-tanzunet-refresh-token))
+      endpoint: ((tanzunet-endpoint))
+      product_slug: vmware-tanzu-greenplum
+      product_version: 5\.25\.0
+
+  - name: previous-5.28.4-release
+    type: tanzunet
+    source:
+      api_token: ((releng/public-tanzunet-refresh-token))
+      endpoint: ((tanzunet-endpoint))
+      product_slug: vmware-tanzu-greenplum
+      product_version: 5\.28\.4
+
+  - name: bin_gpdb6_centos6
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb6/server-rc-(.*)-rhel6_x86_64.tar.gz
+
+  - name: bin_gpdb6_centos7
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.tar.gz
+
+  - name: bin_gpdb6_rhel8
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.tar.gz
+
+  - name: bin_gpdb7_rhel8
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/master/server-rc-(.*)-rhel8_x86_64.tar.gz
+
+  - name: bin_gpdb7_rocky8
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/main/server-rc-(.*)-rocky8_x86_64.tar.gz
+
+  - name: bin_gpdb6_photon3
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb6/server-rc-(.*)-photon3_x86_64.tar.gz
+
+  - name: bin_gpdb6_ubuntu18.04
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
+
+  - name: bin_gpdb6_centos6_with_components
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/bin_gpdb6_centos6_with_components/bin_gpdb.tar.gz
+
+  - name: bin_gpdb6_centos7_with_components
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/bin_gpdb6_centos7_with_components/bin_gpdb.tar.gz
+
+  - name: bin_gpdb6_rhel8_with_components
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/bin_gpdb6_rhel8_with_components/bin_gpdb.tar.gz
+
+  - name: bin_gpdb6_photon3_with_components
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/bin_gpdb6_photon3_with_components/bin_gpdb.tar.gz
+
+  - name: bin_gpdb6_ubuntu18.04_with_components
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/bin_gpdb6_ubuntu18.04_with_components/bin_gpdb.tar.gz
+
+  - name: gpdb6-centos6-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos6-build
+      tag: latest
+
+  - name: gpdb6-centos7-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
+      tag: latest
+
+  - name: gpdb6-rhel8-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb6-rhel8-build
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+      tag: latest
+
+  - name: gpdb7-rhel8-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb7-rhel8-build
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+      tag: latest
+
+  - name: gpdb7-rocky8-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb7-rocky8-build
+      tag: latest
+
+  - name: gpdb6-rhel8-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb6-rhel8-test
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+      tag: latest
+
+  - name: gpdb7-rhel8-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb7-rhel8-test
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+      tag: latest
+
+  - name: gpdb7-rocky8-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb7-rocky8-test
+      tag: latest
+
+  - name: rhel-8
+    type: registry-image
+    source:
+      repository: registry.redhat.io/ubi8/ubi
+      username: ((releng/redhat-registry-username))
+      password: ((releng/redhat-registry-token))
+      tag: latest
+
+  - name: rocky-8
+    type: registry-image
+    source:
+      repository: rockylinux
+      tag: 8
+
+  - name: gpdb6-ubuntu18.04-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-build
+      tag: latest
+
+  - name: gpdb6-sles12-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb6-sles12-build
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+      tag: latest
+
+  - name: gpdb6-sles12-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-private-images/gpdb6-sles12-test
+      username: _json_key
+      password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+      tag: latest
+
+  - name: gpdb6-photon3-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-photon3-build
+      tag: latest
+
+  - name: gpdb6-photon3-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-photon3-test
+      tag: latest
+
+  - name: gpdb5-osl
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: osl/released/gpdb5/open_source_license_GPDB_-_(((gpdb5-osl-version-regex)))_-_GA.txt
+
+  - name: gpdb6-osl
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: osl/released/gpdb6/open_source_license_VMware_Tanzu_Greenplum_Database_(((gpdb6-osl-version-regex)))_GA.txt
+
+  - name: license_file
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-for-oss))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: osl/released/gpdb6/open_source_license_greenplum-database-6.0.0-97773a0-(.*).txt
+
+  - name: gpdb_src
+    type: git
+    source:
+      branch: ((gpdb-git-branch))
+      uri: ((gpdb-git-remote))
+      tag_filter: ((gpdb-git-tag-filter))
+
+  - name: ppa_release_version
+    type: gcs
+    source:
+      json_key: ((concourse-gcs-resources-service-account-key))
+      bucket: ((gcs-bucket-intermediates))
+      versioned_file: ((pipeline-name))/ppa_release_version/version.txt
+
+  - name: rpm_gpdb6_centos6
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_centos6/gpdb6/greenplum-db-6-rhel6-x86_64.rpm
+
+  - name: rpm_gpdb6_centos6_oss
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_centos6/gpdb6/open-source-greenplum-db-6-rhel6-x86_64.rpm
+
+  - name: rpm_gpdb6_rhel8_oss
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb6/open-source-greenplum-db-6-rhel8-x86_64.rpm
+
+  - name: rpm_gpdb6_centos7
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_centos7/gpdb6/greenplum-db-6-rhel7-x86_64.rpm
+
+  - name: rpm_gpdb6_centos7_oss
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_centos7/gpdb6/open-source-greenplum-db-6-rhel7-x86_64.rpm
+
+  - name: rpm_gpdb7_rhel8_oss
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/master/open-source-greenplum-db-7-rhel8-x86_64.rpm
+
+  - name: rpm_gpdb7_rocky8_oss
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_rocky8/gpdb7/open-source-greenplum-db-7-rocky8-x86_64.rpm
+
+  - name: rpm_gpdb6_rhel8
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb6/greenplum-db-6-rhel8-x86_64.rpm
+
+  - name: rpm_gpdb7_rhel8
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb7/greenplum-db-7-rhel8-x86_64.rpm
+
+  - name: rpm_gpdb7_rocky8
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_rocky8/gpdb7/greenplum-db-7-rocky8-x86_64.rpm
+
+  - name: rpm_gpdb6_photon3
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/rpm_gpdb_photon3/greenplum-db-6-photon3-x86_64.rpm
+
+  - name: deb_gpdb6_ubuntu18.04
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/deb_gpdb_ubuntu18.04/greenplum-db-6-ubuntu18.04-amd64.deb
+
+  - name: deb_gpdb6_clients_ubuntu18.04
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/deb_gpdb_clients_ubuntu18.04/greenplum-db-clients-0.0.0-ubuntu18.04-amd64.deb
+
+  - name: deb_gpdb6_ppa_ubuntu18.04
+    type: gcs
+    source:
+      bucket: ((gcs-bucket-intermediates))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      versioned_file: ((pipeline-name))/deb_gpdb6_ppa_ubuntu18.04/greenplum-db-6-ubuntu18.04-amd64.deb
+
+  - name: gpdb6-centos6-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos6-test
+      tag: latest
+
+  - name: gpdb6-centos6-test-packaging
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos6-test-packaging
+      tag: latest
+
+  - name: gpdb6-centos7-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
+      tag: latest
+
+  - name: gpdb6-centos7-test-packaging
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-packaging
+      tag: latest
+
+  - name: gpdb6-ubuntu18.04-test-packaging
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test-packaging
+      tag: latest
+
+## ======================================================================
+##                   _
+##   __ _ _ __   ___| |__   ___  _ __ ___
+##  / _` | '_ \ / __| '_ \ / _ \| '__/ __|
+## | (_| | | | | (__| | | | (_) | |  \__ \
+##  \__,_|_| |_|\___|_| |_|\___/|_|  |___/
+## ======================================================================
+anchors:
+  - gpdb5-rpm-params: &gpdb5-rpm-params
+      GPDB_NAME: greenplum-db-5
+      GPDB_LICENSE: VMware Software EULA
+      GPDB_URL: https://network.tanzu.vmware.com/products/vmware-tanzu-greenplum/
+      GPDB_RELEASE: 1
+  - gpdb6-rpm-params: &gpdb6-rpm-params
+      GPDB_LICENSE: VMware Software EULA
+      GPDB_NAME: greenplum-db-6
+      GPDB_OSS: false
+      GPDB_RELEASE: 1
+      GPDB_URL: https://network.tanzu.vmware.com/products/vmware-tanzu-greenplum/
+  - gpdb7-rpm-params: &gpdb7-rpm-params
+      GPDB_LICENSE: VMware Software EULA
+      GPDB_NAME: greenplum-db-7
+      GPDB_OSS: false
+      GPDB_RELEASE: 1
+      GPDB_URL: https://network.tanzu.vmware.com/products/vmware-tanzu-greenplum/
+  - gpdb6-rpm-params-oss: &gpdb6-rpm-params-oss
+      GPDB_LICENSE: VMware Software EULA
+      GPDB_NAME: open-source-greenplum-db-6
+      GPDB_OSS: true
+      GPDB_RELEASE: 1
+      GPDB_URL: https://github.com/greenplum-db/gpdb
+  - gpdb7-rpm-params-oss: &gpdb7-rpm-params-oss
+      GPDB_LICENSE: VMware Software EULA
+      GPDB_NAME: open-source-greenplum-db-7
+      GPDB_OSS: true
+      GPDB_RELEASE: 1
+      GPDB_URL: https://github.com/greenplum-db/gpdb
+
+## ======================================================================
+##    _       _
+##   (_) ___ | |__  ___
+##   | |/ _ \| '_ \/ __|
+##   | | (_) | |_) \__ \
+##  _/ |\___/|_.__/|___/
+## |__/
+## ======================================================================
+jobs:
+  - name: create_gpdb5_rpm_installer_centos6
+    plan:
+      - in_parallel:
+          - get: bin_gpdb
+            resource: bin_gpdb5_centos6
+            trigger: true
+          - get: license_file
+            resource: gpdb5-osl
+          - get: centos-gpdb-dev-6
+          - get: greenplum-database-release
+            trigger: true
+      - task: build_rpm_gpdb5_centos6
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: centos-gpdb-dev-6
+        params:
+          <<: *gpdb5-rpm-params
+          PLATFORM: "rhel6"
+      - put: rpm_gpdb5_centos6
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb5_rpm_installer_centos7
+    plan:
+      - in_parallel:
+          - get: bin_gpdb
+            resource: bin_gpdb5_centos7
+            trigger: true
+          - get: license_file
+            resource: gpdb5-osl
+          - get: centos-gpdb-dev-7
+          - get: greenplum-database-release
+            trigger: true
+      - task: build_rpm_gpdb5_centos7
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: centos-gpdb-dev-7
+        params:
+          <<: *gpdb5-rpm-params
+          PLATFORM: "rhel7"
+      - put: rpm_gpdb5_centos7
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb5_rpm_installer_sles11
+    plan:
+      - in_parallel:
+          - get: bin_gpdb
+            resource: bin_gpdb5_sles11
+            trigger: true
+          - get: license_file
+            resource: gpdb5-osl
+          - get: greenplum-database-release
+            trigger: true
+          - get: gpdb5-sles11-build-test
+      - task: build_rpm_gpdb5_sles11
+        image: gpdb5-sles11-build-test
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        params:
+          <<: *gpdb5-rpm-params
+          PLATFORM: "sles11"
+      - put: rpm_gpdb5_sles11
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: test_functionality_gpdb5_rpm_centos6
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            passed: [create_gpdb5_rpm_installer_centos6]
+          - get: rpm_gpdb5_centos6
+            passed: [create_gpdb5_rpm_installer_centos6]
+            trigger: true
+          - get: previous-6-release
+            params:
+              globs: [greenplum-db-*-rhel6-x86_64.rpm]
+          - get: previous-6.20.0-release
+            params:
+              globs: [greenplum-db-*-rhel6-x86_64.rpm]
+          - get: previous-5-release
+            params:
+              globs: [greenplum-db-*-rhel6-x86_64.rpm]
+          - get: previous-5.28.4-release
+            params:
+              globs: [greenplum-db-*-rhel6-x86_64.rpm]
+          - get: centos-gpdb-dev-6
+          - get: centos-6
+      - in_parallel:
+          - task: test_rpm_functionality
+            image: centos-gpdb-dev-6
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb5_centos6
+            params:
+              PLATFORM: "rhel6"
+              GPDB_MAJOR_VERSION: "5"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: centos-6
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb5_centos6
+            params:
+              PLATFORM: rhel6
+              GPDB_MAJOR_VERSION: "5"
+
+  - name: test_functionality_gpdb5_rpm_centos7
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            passed: [create_gpdb5_rpm_installer_centos7]
+          - get: rpm_gpdb5_centos7
+            passed: [create_gpdb5_rpm_installer_centos7]
+            trigger: true
+          - get: previous-6-release
+            params:
+              globs: [greenplum-db-*-rhel7-x86_64.rpm]
+          - get: previous-6.20.0-release
+            params:
+              globs: [greenplum-db-*-rhel7-x86_64.rpm]
+          - get: previous-5-release
+            params:
+              globs: [greenplum-db-*-rhel7-x86_64.rpm]
+          - get: previous-5.28.4-release
+            params:
+              globs: [greenplum-db-*-rhel7-x86_64.rpm]
+          - get: centos-gpdb-dev-7
+          - get: centos-7
+      - in_parallel:
+          - task: test_rpm_functionality
+            image: centos-gpdb-dev-7
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb5_centos7
+            params:
+              PLATFORM: "rhel7"
+              GPDB_MAJOR_VERSION: "5"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: centos-7
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb5_centos7
+            params:
+              PLATFORM: rhel7
+              GPDB_MAJOR_VERSION: "5"
+
+  - name: test_functionality_gpdb5_rpm_sles11
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            passed: [create_gpdb5_rpm_installer_sles11]
+          - get: rpm_gpdb5_sles11
+            passed: [create_gpdb5_rpm_installer_sles11]
+            trigger: true
+          - get: previous-5-release
+            params:
+              globs: [greenplum-db-*-sles11-x86_64.rpm]
+          - get: previous-5.28.4-release
+            params:
+              globs: [greenplum-db-*-sles11-x86_64.rpm]
+          - get: gpdb5-sles11-build-test
+      - task: test_rpm_functionality
+        file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm-sles.yml
+        image: gpdb5-sles11-build-test
+        input_mapping:
+          gpdb_rpm_installer: rpm_gpdb5_sles11
+        params:
+          PLATFORM: "sles11"
+          GPDB_MAJOR_VERSION: "5"
+
+  - name: refresh_integrated_components
+    plan:
+      - in_parallel:
+          - get: gp-release-train
+            trigger: true
+          - get: greenplum-database-release
+            trigger: true
+          - get: gp-release
+          - get: start-release-process
+      - task: refresh_components
+        image: start-release-process
+        config:
+          platform: linux
+          inputs:
+            - name: gp-release-train
+            - name: gp-release
+            - name: greenplum-database-release
+          params:
+            BASIC_AUTH_PASSWORD: ((releng/basic_auth_password_releng))
+          run:
+            path: /bin/sh
+            args:
+              - -exc
+              - |
+                fly -t releng login -c https://releng.ci.gpdb.pivotal.io -u pivotal -p ${BASIC_AUTH_PASSWORD}
+                export WORKSPACE=`pwd`
+                FLY_OPTION_NON_INTERACTIVE="-n" make -C greenplum-database-release set-gpdb-package-testing-prod
+
+  - name: gpdb_component_packaging_centos6
+    plan:
+      - in_parallel:
+          - get: gp-greenplum-morgan-stanley
+          - get: bin_gpdb6_centos6
+            trigger: true
+          - get: google-cloud-build
+          - get: gp-release
+            passed:
+              - refresh_integrated_components
+          - get: greenplum-database-release
+            passed:
+              - refresh_integrated_components
+            trigger: true
+      - file: gp-release/gpdb6/concourse/tasks/add_components.yml
+        image: google-cloud-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos6
+        output_mapping:
+          bin_gpdb_with_components: bin_gpdb_centos6_with_components
+        task: add_components_to_bin_gpdb_centos6
+        params:
+          COMPONENT_GPSS_LOCATION: ((gpss-RHEL6-gcs-location))
+          COMPONENT_DISKQUOTA_LOCATION: ((diskquota-RHEL6-gcs-location))
+          COMPONENT_METRICS_COLLECTOR_LOCATION: ((metrics-collector-RHEL6-gcs-location))
+          COMPONENT_ADVANCED_PASSWORD_CHECK_LOCATION: ((advanced-password-check-RHEL6-gcs-location))
+          COMPONENT_GPMT_LOCATION: ((gpmt-RHEL6-gcs-location))
+          COMPONENT_IP4R_LOCATION: ((ip4r-RHEL6-gcs-location))
+          COMPONENT_POSTGRESQL_HLL_LOCATION: ((postgresql-hll-RHEL6-gcs-location))
+          COMPONENT_GPTEXT_GPCC_PLUGIN_LOCATION: ((gptext-gpcc-plugin-RHEL6-gcs-location))
+          GCLOUD_SERVICE_ACCOUNT_KEY: ((concourse-gcs-resources-service-account-key))
+      - params:
+          file: bin_gpdb_centos6_with_components/bin_gpdb.tar.gz
+        put: bin_gpdb6_centos6_with_components
+
+  - name: gpdb_component_packaging_centos7
+    plan:
+      - in_parallel:
+          - get: gp-greenplum-morgan-stanley
+          - get: bin_gpdb6_centos7
+            trigger: true
+          - get: google-cloud-build
+          - get: gp-release
+            passed:
+              - refresh_integrated_components
+          - get: greenplum-database-release
+            passed:
+              - refresh_integrated_components
+            trigger: true
+      - file: gp-release/gpdb6/concourse/tasks/add_components.yml
+        image: google-cloud-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos7
+        output_mapping:
+          bin_gpdb_with_components: bin_gpdb_centos7_with_components
+        task: add_components_to_bin_gpdb_centos7
+        params:
+          COMPONENT_GPSS_LOCATION: ((gpss-RHEL7-gcs-location))
+          COMPONENT_DISKQUOTA_LOCATION: ((diskquota-RHEL7-gcs-location))
+          COMPONENT_METRICS_COLLECTOR_LOCATION: ((metrics-collector-RHEL7-gcs-location))
+          COMPONENT_ADVANCED_PASSWORD_CHECK_LOCATION: ((advanced-password-check-RHEL7-gcs-location))
+          COMPONENT_GPMT_LOCATION: ((gpmt-RHEL7-gcs-location))
+          COMPONENT_PLPYTHON3_LOCATION: ((plpython3-RHEL7-gcs-location))
+          COMPONENT_IP4R_LOCATION: ((ip4r-RHEL7-gcs-location))
+          COMPONENT_POSTGRESQL_HLL_LOCATION: ((postgresql-hll-RHEL7-gcs-location))
+          COMPONENT_GPTEXT_GPCC_PLUGIN_LOCATION: ((gptext-gpcc-plugin-RHEL7-gcs-location))
+          GCLOUD_SERVICE_ACCOUNT_KEY: ((concourse-gcs-resources-service-account-key))
+      - params:
+          file: bin_gpdb_centos7_with_components/bin_gpdb.tar.gz
+        put: bin_gpdb6_centos7_with_components
+
+  - name: gpdb_component_packaging_rhel8
+    plan:
+      - in_parallel:
+          - get: gp-greenplum-morgan-stanley
+          - get: bin_gpdb6_rhel8
+            trigger: true
+          - get: google-cloud-build
+          - get: gp-release
+            passed:
+              - refresh_integrated_components
+          - get: greenplum-database-release
+            passed:
+              - refresh_integrated_components
+            trigger: true
+      - file: gp-release/gpdb6/concourse/tasks/add_components.yml
+        image: google-cloud-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_rhel8
+        output_mapping:
+          bin_gpdb_with_components: bin_gpdb_rhel8_with_components
+        task: add_components_to_bin_gpdb_rhel8
+        params:
+          COMPONENT_GPSS_LOCATION: ((gpss-RHEL8-gcs-location))
+          COMPONENT_DISKQUOTA_LOCATION: ((diskquota-RHEL8-gcs-location))
+          COMPONENT_METRICS_COLLECTOR_LOCATION: ((metrics-collector-RHEL8-gcs-location))
+          COMPONENT_ADVANCED_PASSWORD_CHECK_LOCATION: ((advanced-password-check-RHEL8-gcs-location))
+          COMPONENT_GPMT_LOCATION: ((gpmt-RHEL8-gcs-location))
+          COMPONENT_PLPYTHON3_LOCATION: ((plpython3-RHEL8-gcs-location))
+          COMPONENT_IP4R_LOCATION: ((ip4r-RHEL8-gcs-location))
+          COMPONENT_POSTGRESQL_HLL_LOCATION: ((postgresql-hll-RHEL8-gcs-location))
+          COMPONENT_GPTEXT_GPCC_PLUGIN_LOCATION: ((gptext-gpcc-plugin-RHEL8-gcs-location))
+          GCLOUD_SERVICE_ACCOUNT_KEY: ((concourse-gcs-resources-service-account-key))
+      - params:
+          file: bin_gpdb_rhel8_with_components/bin_gpdb.tar.gz
+        put: bin_gpdb6_rhel8_with_components
+
+  - name: gpdb_component_packaging_photon3
+    plan:
+      - in_parallel:
+          - get: gp-greenplum-morgan-stanley
+          - get: bin_gpdb6_photon3
+            trigger: true
+          - get: google-cloud-build
+          - get: gp-release
+            passed:
+              - refresh_integrated_components
+          - get: greenplum-database-release
+            passed:
+              - refresh_integrated_components
+            trigger: true
+      - file: gp-release/gpdb6/concourse/tasks/add_components.yml
+        image: google-cloud-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_photon3
+        output_mapping:
+          bin_gpdb_with_components: bin_gpdb_photon3_with_components
+        task: add_components_to_bin_gpdb_photon3
+        params:
+          COMPONENT_METRICS_COLLECTOR_LOCATION: ((metrics-collector-PHOTON3-gcs-location))
+          GCLOUD_SERVICE_ACCOUNT_KEY: ((concourse-gcs-resources-service-account-key))
+      - params:
+          file: bin_gpdb_photon3_with_components/bin_gpdb.tar.gz
+        put: bin_gpdb6_photon3_with_components
+
+  - name: gpdb_component_packaging_ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: gp-greenplum-morgan-stanley
+          - get: bin_gpdb6_ubuntu18.04
+            trigger: true
+          - get: google-cloud-build
+          - get: gp-release
+            passed:
+              - refresh_integrated_components
+          - get: greenplum-database-release
+            passed:
+              - refresh_integrated_components
+            trigger: true
+      - file: gp-release/gpdb6/concourse/tasks/add_components.yml
+        image: google-cloud-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_ubuntu18.04
+        output_mapping:
+          bin_gpdb_with_components: bin_gpdb_ubuntu18.04_with_components
+        task: add_components_to_bin_gpdb_ubuntu18.04
+        params:
+          COMPONENT_GPSS_LOCATION: ((gpss-BIONIC-gcs-location))
+          COMPONENT_DISKQUOTA_LOCATION: ((diskquota-BIONIC-gcs-location))
+          COMPONENT_METRICS_COLLECTOR_LOCATION: ((metrics-collector-BIONIC-gcs-location))
+          COMPONENT_ADVANCED_PASSWORD_CHECK_LOCATION: ((advanced-password-check-BIONIC-gcs-location))
+          COMPONENT_GPMT_LOCATION: ((gpmt-BIONIC-gcs-location))
+          COMPONENT_PLPYTHON3_LOCATION: ((plpython3-BIONIC-gcs-location))
+          COMPONENT_IP4R_LOCATION: ((ip4r-BIONIC-gcs-location))
+          COMPONENT_POSTGRESQL_HLL_LOCATION: ((postgresql-hll-BIONIC-gcs-location))
+          GCLOUD_SERVICE_ACCOUNT_KEY: ((concourse-gcs-resources-service-account-key))
+      - params:
+          file: bin_gpdb_ubuntu18.04_with_components/bin_gpdb.tar.gz
+        put: bin_gpdb6_ubuntu18.04_with_components
+
+  - name: create_gpdb6_rpm_installer_centos6
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_centos6_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_centos6
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_centos6
+          - get: gpdb6-centos6-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-centos6-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos6_with_components
+      - task: build_rpm_gpdb6_centos6
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-centos6-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos6_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params
+          PLATFORM: rhel6
+      - put: rpm_gpdb6_centos6
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_rpm_installer_centos6_oss
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_centos6
+          - get: bin_gpdb6_centos6_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_centos6
+          - get: gpdb6-centos6-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-centos6-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos6_with_components
+      - task: build_rpm_gpdb6_centos6
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-centos6-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos6_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params-oss
+          PLATFORM: rhel6
+          GPDB_NAME: greenplum-db-6
+      - put: rpm_gpdb6_centos6_oss
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_rpm_installer_centos7
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_centos7_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_centos7
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_centos7
+          - get: gpdb6-centos7-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-centos7-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos7_with_components
+      - task: build_rpm_gpdb6_centos7
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-centos7-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos7_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params
+          PLATFORM: rhel7
+      - put: rpm_gpdb6_centos7
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_rpm_installer_centos7_oss
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_centos7
+          - get: bin_gpdb6_centos7_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_centos7
+          - get: gpdb6-centos7-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-centos7-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos7_with_components
+      - task: build_rpm_gpdb6_centos7
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-centos7-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_centos7_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params-oss
+          PLATFORM: rhel7
+          GPDB_NAME: greenplum-db-6
+      - put: rpm_gpdb6_centos7_oss
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_rpm_installer_rhel8
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_rhel8_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_rhel8
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_rhel8
+          - get: gpdb6-rhel8-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_rhel8_with_components
+      - task: build_rpm_gpdb6_rhel8
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_rhel8_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params
+          PLATFORM: rhel8
+      - put: rpm_gpdb6_rhel8
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_rpm_installer_rhel8_oss
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_rhel8
+          - get: bin_gpdb6_rhel8_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_rhel8
+          - get: gpdb6-rhel8-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_rhel8_with_components
+      - task: build_rpm_gpdb6_rhel8
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_rhel8_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params-oss
+          PLATFORM: rhel8
+          GPDB_NAME: greenplum-db-6
+      - put: rpm_gpdb6_rhel8_oss
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_rpm_installer_photon3
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_photon3_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_photon3
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_photon3
+          - get: gpdb6-photon3-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb6_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb6-photon3-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_photon3_with_components
+      - task: build_rpm_gpdb6_photon3
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb6-photon3-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_photon3_with_components
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb6-rpm-params
+          PLATFORM: photon3
+      - put: rpm_gpdb6_photon3
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb6_deb_installer_ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_ubuntu18.04_with_components
+            trigger: true
+            passed:
+              - gpdb_component_packaging_ubuntu18.04
+          - get: greenplum-database-release
+            passed:
+              - gpdb_component_packaging_ubuntu18.04
+          - get: gpdb6-ubuntu18.04-build
+          - get: gpdb6-osl
+      - task: build_deb_gpdb6_ubuntu18.04
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-deb.yml
+        image: gpdb6-ubuntu18.04-build
+        input_mapping:
+          bin_gpdb: bin_gpdb6_ubuntu18.04_with_components
+          license_file: gpdb6-osl
+        params:
+          GPDB_OSS: false
+          PLATFORM: ubuntu18.04
+      - put: deb_gpdb6_ubuntu18.04
+        params:
+          file: gpdb_deb_installer/*.deb
+
+  - name: create_gpdb6_clients_deb_installer_ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_clients_ubuntu18.04
+            trigger: true
+          - get: gpdb6-ubuntu18.04-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-deb.yml
+            image: gpdb6-ubuntu18.04-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb6_clients_ubuntu18.04
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: ubuntu18.04
+            task: build_deb_gpdb6_clients_ubuntu18.04
+      - in_parallel:
+          - params:
+              file: gpdb_clients_deb_installer/*.deb
+            put: deb_gpdb6_clients_ubuntu18.04
+
+  - name: create_gpdb6_deb_ppa_installer_ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            trigger: true
+          - get: bin_gpdb6_ubuntu18.04_for_ppa
+            trigger: true
+          - get: gpdb6-ubuntu18.04-build
+          - get: license_file
+          - get: gpdb_src
+      - task: build ppa
+        file: greenplum-database-release/ci/concourse/tasks/build-ppa.yml
+        image: gpdb6-ubuntu18.04-build
+        params:
+          GPG_PRIVATE_KEY: ((releng/gpg-private-key/env))
+          RELEASE_MESSAGE: ((release-message))
+          DEBFULLNAME: ((debian-package-maintainer-fullname))
+          DEBEMAIL: ((debian-package-maintainer-email))
+          GPDB_OSS: true
+          PLATFORM: "ubuntu18.04"
+          PPA: true
+        input_mapping:
+          bin_gpdb: bin_gpdb6_ubuntu18.04_for_ppa
+      - in_parallel:
+          - put: deb_gpdb6_ppa_ubuntu18.04
+            params:
+              file: gpdb_deb_ppa_installer/*.deb
+          - put: ppa_release_version
+            params:
+              file: ppa_release/version.txt
+
+  - name: create_gpdb6_clients_rpm_installer_centos6
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_clients_centos6
+            trigger: true
+          - get: gpdb6-centos6-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
+            image: gpdb6-centos6-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb6_clients_centos6
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: rhel6
+            task: build_rpm_gpdb_centos6
+      - in_parallel:
+          - params:
+              file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rhel6-x86_64.rpm
+            put: rpm_gpdb6_clients_centos6
+
+  - name: create_gpdb6_clients_rpm_installer_centos7
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_clients_centos7
+            trigger: true
+          - get: gpdb6-centos7-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
+            image: gpdb6-centos7-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb6_clients_centos7
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: rhel7
+            task: build_rpm_gpdb_centos7
+      - in_parallel:
+          - params:
+              file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rhel7-x86_64.rpm
+            put: rpm_gpdb6_clients_centos7
+
+  - name: create_gpdb6_clients_rpm_installer_rhel8
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_clients_rhel8
+            trigger: true
+          - get: gpdb6-rhel8-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
+            image: gpdb6-rhel8-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb6_clients_rhel8
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: rhel8
+            task: build_rpm_gpdb_rhel8
+      - in_parallel:
+          - params:
+              file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rhel8-x86_64.rpm
+            put: rpm_gpdb6_clients_rhel8
+
+  - name: create_gpdb6_clients_rpm_installer_sles12
+    plan:
+      - in_parallel:
+          - get: bin_gpdb6_clients_sles12
+            trigger: true
+          - get: gpdb6-sles12-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
+            image: gpdb6-sles12-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb6_clients_sles12
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: sles12
+            task: build_rpm_gpdb_sles12
+      - in_parallel:
+          - params:
+              file: gpdb_clients_rpm_installer/greenplum-db-clients-*-sles12-x86_64.rpm
+            put: rpm_gpdb6_clients_sles12
+
+  - name: test_functionality_gpdb6_rpm_centos6
+    plan:
+      - in_parallel:
+          - get: previous-6-release
+            params:
+              globs:
+                - greenplum-db-*-rhel6-x86_64.rpm
+          - get: previous-6.20.0-release
+            params:
+              globs:
+                - greenplum-db-*-rhel6-x86_64.rpm
+          - get: previous-5-release
+            params:
+              globs:
+                - greenplum-db-*-rhel6-x86_64.rpm
+          - get: previous-5.28.4-release
+            params:
+              globs:
+                - greenplum-db-*-rhel6-x86_64.rpm
+          - get: rpm_gpdb6_centos6
+            passed:
+              - create_gpdb6_rpm_installer_centos6
+            trigger: true
+          - get: rpm_gpdb6_centos6_oss
+            passed:
+              - create_gpdb6_rpm_installer_centos6_oss
+            trigger: true
+          - get: previous-6-oss-release
+            params:
+              globs:
+                - open-source-greenplum-db-*-rhel6-x86_64.rpm
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_rpm_installer_centos6
+          - get: gpdb6-centos6-test
+          - get: centos-6
+      - in_parallel:
+          - task: test_gpdb6_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            image: gpdb6-centos6-test
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb6_centos6
+              gpdb_rpm_oss_installer: rpm_gpdb6_centos6_oss
+            params:
+              PLATFORM: rhel6
+              GPDB_MAJOR_VERSION: "6"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: centos-6
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb6_centos6
+            params:
+              PLATFORM: rhel6
+              GPDB_MAJOR_VERSION: "6"
+
+  - name: test_functionality_clients_gpdb6_rpm_centos6
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb6_clients_centos6
+            passed:
+              - create_gpdb6_clients_rpm_installer_centos6
+            trigger: true
+          - get: gpdb6-centos6-test-packaging
+          - get: centos-6
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_clients_rpm_installer_centos6
+      - in_parallel:
+          - task: test_clients_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+            image: gpdb6-centos6-test-packaging
+            input_mapping:
+              gpdb_clients_package_installer: rpm_gpdb6_clients_centos6
+            params:
+              PLATFORM: rhel6
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: centos-6
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb6_clients_centos6
+            params:
+              PLATFORM: rhel6
+              GPDB_MAJOR_VERSION: "6"
+              CLIENTS: "clients"
+
+  - name: test_functionality_gpdb6_rpm_centos7
+    plan:
+      - in_parallel:
+          - get: previous-6-release
+            params:
+              globs:
+                - greenplum-db-*-rhel7-x86_64.rpm
+          - get: previous-6.20.0-release
+            params:
+              globs:
+                - greenplum-db-*-rhel7-x86_64.rpm
+          - get: previous-5-release
+            params:
+              globs:
+                - greenplum-db-*-rhel7-x86_64.rpm
+          - get: previous-5.28.4-release
+            params:
+              globs:
+                - greenplum-db-*-rhel7-x86_64.rpm
+          - get: rpm_gpdb6_centos7
+            passed:
+              - create_gpdb6_rpm_installer_centos7
+            trigger: true
+          - get: rpm_gpdb6_centos7_oss
+            passed:
+              - create_gpdb6_rpm_installer_centos7_oss
+            trigger: true
+          - get: previous-6-oss-release
+            params:
+              globs:
+                - open-source-greenplum-db-*-rhel7-x86_64.rpm
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_rpm_installer_centos7
+          - get: gpdb6-centos7-test
+          - get: centos-7
+      - in_parallel:
+          - task: test_gpdb6_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            image: gpdb6-centos7-test
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb6_centos7
+              gpdb_rpm_oss_installer: rpm_gpdb6_centos7_oss
+            params:
+              PLATFORM: rhel7
+              GPDB_MAJOR_VERSION: "6"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: centos-7
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb6_centos7
+            params:
+              PLATFORM: rhel7
+              GPDB_MAJOR_VERSION: "6"
+
+  - name: test_functionality_clients_gpdb6_rpm_centos7
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb6_clients_centos7
+            passed:
+              - create_gpdb6_clients_rpm_installer_centos7
+            trigger: true
+          - get: gpdb6-centos7-test-packaging
+          - get: centos-7
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_clients_rpm_installer_centos7
+      - in_parallel:
+          - task: test_clients_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+            image: gpdb6-centos7-test-packaging
+            input_mapping:
+              gpdb_clients_package_installer: rpm_gpdb6_clients_centos7
+            params:
+              PLATFORM: rhel7
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: centos-7
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb6_clients_centos7
+            params:
+              PLATFORM: rhel7
+              GPDB_MAJOR_VERSION: "6"
+              CLIENTS: "clients"
+
+  - name: test_functionality_gpdb6_rpm_rhel8
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb6_rhel8
+            passed:
+              - create_gpdb6_rpm_installer_rhel8
+            trigger: true
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_rpm_installer_rhel8
+          - get: gpdb6-rhel8-test
+          - get: rhel-8
+          - get: previous-6.20.0-release
+            params:
+              globs:
+                - greenplum-db-*-rhel8-x86_64.rpm
+          - get: previous-6-oss-release
+            params:
+              globs:
+                - open-source-greenplum-db-*-rhel8-x86_64.rpm
+          - get: rpm_gpdb6_rhel8_oss
+            passed:
+              - create_gpdb6_rpm_installer_rhel8_oss
+            trigger: true
+      - in_parallel:
+          - task: test_gpdb6_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            image: gpdb6-rhel8-test
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb6_rhel8
+              gpdb_rpm_oss_installer: rpm_gpdb6_rhel8_oss
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "6"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: rhel-8
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb6_rhel8
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "6"
+              REDHAT_SUBSCRIPTION_ORG_ID: ((releng/redhat_subscription_org_id))
+              REDHAT_SUBSCRIPTION_KEY_ID: ((releng/redhat_subscription_key_id))
+
+  - name: test_functionality_gpdb6_deb_ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: deb_gpdb6_ubuntu18.04
+            passed:
+              - create_gpdb6_deb_installer_ubuntu18.04
+            trigger: true
+          - get: deb_gpdb6_ppa_ubuntu18.04
+            passed:
+              - create_gpdb6_deb_ppa_installer_ubuntu18.04
+            trigger: true
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_deb_installer_ubuntu18.04
+          - get: gpdb6-ubuntu18.04-test-packaging
+          - get: ubuntu-18.04
+          - get: previous-6.20.0-release
+            params:
+              globs:
+                - greenplum-db-6.*-ubuntu18.04-amd64.deb
+          - get: previous_gpdb_deb_ppa_installer
+      - in_parallel:
+          - task: test_gpdb6_deb_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-deb.yml
+            image: gpdb6-ubuntu18.04-test-packaging
+            input_mapping:
+              gpdb_deb_installer: deb_gpdb6_ubuntu18.04
+              gpdb_deb_ppa_installer: deb_gpdb6_ppa_ubuntu18.04
+              previous_gpdb_deb_installer: previous-6.20.0-release
+            params:
+              PLATFORM: ubuntu18.04
+              GPDB_MAJOR_VERSION: "6"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: ubuntu-18.04
+            input_mapping:
+              gpdb_pkg_installer: deb_gpdb6_ubuntu18.04
+            params:
+              PLATFORM: ubuntu18.04
+              GPDB_MAJOR_VERSION: "6"
+
+  - name: test_functionality_gpdb6_rpm_photon3
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb6_photon3
+            passed:
+              - create_gpdb6_rpm_installer_photon3
+            trigger: true
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_rpm_installer_photon3
+          - get: gpdb6-photon3-test
+      - task: test_gpdb6_rpm_functionality
+        file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+        image: gpdb6-photon3-test
+        input_mapping:
+          gpdb_rpm_installer: rpm_gpdb6_photon3
+        params:
+          PLATFORM: photon3
+          GPDB_MAJOR_VERSION: "6"
+
+  - name: test_functionality_clients_gpdb6_deb_ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: deb_gpdb6_clients_ubuntu18.04
+            passed:
+              - create_gpdb6_clients_deb_installer_ubuntu18.04
+            trigger: true
+          - get: gpdb6-ubuntu18.04-test-packaging
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_clients_deb_installer_ubuntu18.04
+          - get: ubuntu-18.04
+      - in_parallel:
+          - task: test_clients_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+            image: gpdb6-ubuntu18.04-test-packaging
+            input_mapping:
+              gpdb_clients_package_installer: deb_gpdb6_clients_ubuntu18.04
+            params:
+              PLATFORM: ubuntu18.04
+              GPDB_MAJOR_VERSION: "6"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: ubuntu-18.04
+            input_mapping:
+              gpdb_pkg_installer: deb_gpdb6_clients_ubuntu18.04
+            params:
+              PLATFORM: ubuntu18.04
+              GPDB_MAJOR_VERSION: "6"
+              CLIENTS: "clients"
+
+
+  - name: test_functionality_clients_gpdb6_rpm_rhel8
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb6_clients_rhel8
+            passed:
+              - create_gpdb6_clients_rpm_installer_rhel8
+            trigger: true
+          - get: gpdb6-rhel8-build
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_clients_rpm_installer_rhel8
+          - get: rhel-8
+      - in_parallel:
+          - task: test_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+            image: gpdb6-rhel8-build
+            input_mapping:
+              gpdb_clients_package_installer: rpm_gpdb6_clients_rhel8
+            params:
+              PLATFORM: rhel8
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: rhel-8
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb6_clients_rhel8
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "6"
+              CLIENTS: "clients"
+              REDHAT_SUBSCRIPTION_ORG_ID: ((releng/redhat_subscription_org_id))
+              REDHAT_SUBSCRIPTION_KEY_ID: ((releng/redhat_subscription_key_id))
+
+  - name: test_functionality_clients_gpdb6_rpm_sles12
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb6_clients_sles12
+            passed:
+              - create_gpdb6_clients_rpm_installer_sles12
+            trigger: true
+          - get: gpdb6-sles12-test
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb6_clients_rpm_installer_sles12
+      - task: test_rpm_functionality
+        file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+        image: gpdb6-sles12-test
+        input_mapping:
+          gpdb_clients_package_installer: rpm_gpdb6_clients_sles12
+        params:
+          PLATFORM: sles12
+
+  - name: create_gpdb7_rpm_installer_rhel8_oss
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            trigger: true
+          - get: bin_gpdb7_rhel8
+            trigger: true
+          - get: gpdb7-rhel8-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb7_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb7-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rhel8
+      - task: build_rpm_gpdb7_rhel8
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb7-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rhel8
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb7-rpm-params-oss
+          PLATFORM: rhel8
+          GPDB_NAME: greenplum-db-7
+      - put: rpm_gpdb7_rhel8_oss
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb7_rpm_installer_rocky8_oss
+    plan:
+      - in_parallel:
+          - get: greenplum-database-release
+            trigger: true
+          - get: bin_gpdb7_rocky8
+            trigger: true
+          - get: gpdb7-rocky8-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb7_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb7-rocky8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rocky8
+      - task: build_rpm_gpdb7_rocky8
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb7-rocky8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rocky8
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb7-rpm-params-oss
+          PLATFORM: rocky8
+          GPDB_NAME: greenplum-db-7
+      - put: rpm_gpdb7_rocky8_oss
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb7_rpm_installer_rhel8
+    plan:
+      - in_parallel:
+          - get: bin_gpdb7_rhel8
+            trigger: true
+          - get: greenplum-database-release
+            trigger: true
+          - get: gpdb7-rhel8-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb7_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb7-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rhel8
+      - task: build_rpm_gpdb7_rhel8
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb7-rhel8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rhel8
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb7-rpm-params
+          PLATFORM: rhel8
+      - put: rpm_gpdb7_rhel8
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb7_rpm_installer_rocky8
+    plan:
+      - in_parallel:
+          - get: bin_gpdb7_rocky8
+            trigger: true
+          - get: greenplum-database-release
+            trigger: true
+          - get: gpdb7-rocky8-build
+          - get: gpdb6-osl
+      - task: retrieve_gpdb7_src
+        file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
+        image: gpdb7-rocky8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rocky8
+      - task: build_rpm_gpdb7_rocky8
+        file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
+        image: gpdb7-rocky8-build
+        input_mapping:
+          bin_gpdb: bin_gpdb7_rocky8
+          license_file: gpdb6-osl
+        params:
+          <<: *gpdb7-rpm-params
+          PLATFORM: rocky8
+      - put: rpm_gpdb7_rocky8
+        params:
+          file: gpdb_rpm_installer/*.rpm
+
+  - name: create_gpdb7_clients_rpm_installer_rhel8
+    plan:
+      - in_parallel:
+          - get: bin_gpdb7_clients_rhel8
+            trigger: true
+          - get: gpdb7-rhel8-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
+            image: gpdb7-rhel8-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb7_clients_rhel8
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "7"
+            task: build_rpm_gpdb_rhel8
+      - in_parallel:
+          - params:
+              file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rhel8-x86_64.rpm
+            put: rpm_gpdb7_clients_rhel8
+
+  - name: create_gpdb7_clients_rpm_installer_rocky8
+    plan:
+      - in_parallel:
+          - get: bin_gpdb7_clients_rocky8
+            trigger: true
+          - get: gpdb7-rocky8-build
+          - get: greenplum-database-release
+            trigger: true
+      - in_parallel:
+          - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
+            image: gpdb7-rocky8-build
+            input_mapping:
+              bin_gpdb_clients: bin_gpdb7_clients_rocky8
+            params:
+              GPDB_VERSION: 0.0.0
+              PLATFORM: rocky8
+              GPDB_MAJOR_VERSION: "7"
+            task: build_rpm_gpdb_rocky8
+      - in_parallel:
+          - params:
+              file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rocky8-x86_64.rpm
+            put: rpm_gpdb7_clients_rocky8
+
+  - name: test_functionality_gpdb7_rpm_rhel8
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb7_rhel8
+            passed:
+              - create_gpdb7_rpm_installer_rhel8
+            trigger: true
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb7_rpm_installer_rhel8
+          - get: gpdb7-rhel8-test
+          - get: rhel-8
+          - get: previous-6-oss-release
+            params:
+              globs:
+                - open-source-greenplum-db-*-rhel8-x86_64.rpm
+          - get: rpm_gpdb7_rhel8_oss
+            passed:
+              - create_gpdb7_rpm_installer_rhel8_oss
+            trigger: true
+          - get: previous-6.20.0-release
+            params:
+              globs:
+                - greenplum-db-*-rhel8-x86_64.rpm
+      - in_parallel:
+          - task: test_gpdb7_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            image: gpdb7-rhel8-test
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb7_rhel8
+              gpdb_rpm_oss_installer: rpm_gpdb7_rhel8_oss
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "7"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: rhel-8
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb7_rhel8
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "7"
+              REDHAT_SUBSCRIPTION_ORG_ID: ((releng/redhat_subscription_org_id))
+              REDHAT_SUBSCRIPTION_KEY_ID: ((releng/redhat_subscription_key_id))
+
+  - name: test_functionality_gpdb7_rpm_rocky8
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb7_rocky8
+            passed:
+              - create_gpdb7_rpm_installer_rocky8
+            trigger: true
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb7_rpm_installer_rocky8
+          - get: gpdb7-rocky8-test
+          - get: rocky-8
+          - get: rpm_gpdb7_rocky8_oss
+            passed:
+              - create_gpdb7_rpm_installer_rocky8_oss
+            trigger: true
+      - in_parallel:
+          - task: test_gpdb7_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
+            image: gpdb7-rocky8-test
+            input_mapping:
+              gpdb_rpm_installer: rpm_gpdb7_rocky8
+              gpdb_rpm_oss_installer: rpm_gpdb7_rocky8_oss
+            params:
+              PLATFORM: rocky8
+              GPDB_MAJOR_VERSION: "7"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: rocky-8
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb7_rocky8
+            params:
+              PLATFORM: rocky8
+              GPDB_MAJOR_VERSION: "7"
+
+  - name: test_functionality_clients_gpdb7_rpm_rhel8
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb7_clients_rhel8
+            passed:
+              - create_gpdb7_clients_rpm_installer_rhel8
+            trigger: true
+          - get: gpdb7-rhel8-build
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb7_clients_rpm_installer_rhel8
+          - get: rhel-8
+          - get: rpm_gpdb7_rhel8_oss
+            passed:
+              - create_gpdb7_rpm_installer_rhel8_oss
+      - in_parallel:
+          - task: test_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+            image: gpdb7-rhel8-build
+            input_mapping:
+              gpdb_clients_package_installer: rpm_gpdb7_clients_rhel8
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "7"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: rhel-8
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb7_clients_rhel8
+            params:
+              PLATFORM: rhel8
+              GPDB_MAJOR_VERSION: "7"
+              CLIENTS: "clients"
+              REDHAT_SUBSCRIPTION_ORG_ID: ((releng/redhat_subscription_org_id))
+              REDHAT_SUBSCRIPTION_KEY_ID: ((releng/redhat_subscription_key_id))
+
+  - name: test_functionality_clients_gpdb7_rpm_rocky8
+    plan:
+      - in_parallel:
+          - get: rpm_gpdb7_clients_rocky8
+            passed:
+              - create_gpdb7_clients_rpm_installer_rocky8
+            trigger: true
+          - get: gpdb7-rocky8-build
+          - get: greenplum-database-release
+            passed:
+              - create_gpdb7_clients_rpm_installer_rocky8
+          - get: rocky-8
+          - get: rpm_gpdb7_rocky8_oss
+            passed:
+              - create_gpdb7_rpm_installer_rocky8_oss
+      - in_parallel:
+          - task: test_rpm_functionality
+            file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
+            image: gpdb7-rocky8-build
+            input_mapping:
+              gpdb_clients_package_installer: rpm_gpdb7_clients_rocky8
+            params:
+              PLATFORM: rocky8
+              GPDB_MAJOR_VERSION: "7"
+          - task: test_package_dependencies
+            file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
+            image: rocky-8
+            input_mapping:
+              gpdb_pkg_installer: rpm_gpdb7_clients_rocky8
+            params:
+              PLATFORM: rocky8
+              GPDB_MAJOR_VERSION: "7"
+              CLIENTS: "clients"
+
+groups:
+  - jobs:
+      - create_gpdb5_rpm_installer_sles11
+      - test_functionality_gpdb5_rpm_sles11
+      - create_gpdb5_rpm_installer_centos6
+      - test_functionality_gpdb5_rpm_centos6
+      - create_gpdb5_rpm_installer_centos7
+      - test_functionality_gpdb5_rpm_centos7
+      - create_gpdb6_rpm_installer_centos6
+      - test_functionality_gpdb6_rpm_centos6
+      - create_gpdb6_rpm_installer_centos7
+      - test_functionality_gpdb6_rpm_centos7
+      - create_gpdb6_rpm_installer_rhel8
+      - test_functionality_gpdb6_rpm_rhel8
+      - create_gpdb6_rpm_installer_photon3
+      - test_functionality_gpdb6_rpm_photon3
+      - create_gpdb6_deb_installer_ubuntu18.04
+      - test_functionality_gpdb6_deb_ubuntu18.04
+      - create_gpdb6_clients_rpm_installer_sles12
+      - test_functionality_clients_gpdb6_rpm_sles12
+      - create_gpdb6_clients_rpm_installer_centos6
+      - test_functionality_clients_gpdb6_rpm_centos6
+      - create_gpdb6_clients_rpm_installer_centos7
+      - test_functionality_clients_gpdb6_rpm_centos7
+      - create_gpdb6_clients_rpm_installer_rhel8
+      - test_functionality_clients_gpdb6_rpm_rhel8
+      - create_gpdb6_clients_deb_installer_ubuntu18.04
+      - test_functionality_clients_gpdb6_deb_ubuntu18.04
+      - create_gpdb6_deb_ppa_installer_ubuntu18.04
+      - create_gpdb6_rpm_installer_centos6_oss
+      - create_gpdb6_rpm_installer_centos7_oss
+      - create_gpdb7_clients_rpm_installer_rhel8
+      - create_gpdb7_clients_rpm_installer_rocky8
+      - test_functionality_clients_gpdb7_rpm_rhel8
+      - test_functionality_clients_gpdb7_rpm_rocky8
+      - create_gpdb7_rpm_installer_rhel8
+      - create_gpdb7_rpm_installer_rocky8
+      - test_functionality_gpdb7_rpm_rhel8
+      - test_functionality_gpdb7_rpm_rocky8
+      - create_gpdb6_rpm_installer_rhel8_oss
+      - create_gpdb7_rpm_installer_rhel8_oss
+      - create_gpdb7_rpm_installer_rocky8_oss
+      - gpdb_component_packaging_centos6
+      - gpdb_component_packaging_centos7
+      - gpdb_component_packaging_rhel8
+      - gpdb_component_packaging_ubuntu18.04
+      - gpdb_component_packaging_photon3
+      - refresh_integrated_components
+    name: All
+  - jobs:
+      - create_gpdb5_rpm_installer_sles11
+      - test_functionality_gpdb5_rpm_sles11
+      - create_gpdb5_rpm_installer_centos6
+      - test_functionality_gpdb5_rpm_centos6
+      - create_gpdb5_rpm_installer_centos7
+      - test_functionality_gpdb5_rpm_centos7
+    name: gpdb 5
+  - jobs:
+      - create_gpdb6_rpm_installer_centos6
+      - test_functionality_gpdb6_rpm_centos6
+      - create_gpdb6_rpm_installer_centos7
+      - test_functionality_gpdb6_rpm_centos7
+      - create_gpdb6_rpm_installer_rhel8
+      - test_functionality_gpdb6_rpm_rhel8
+      - create_gpdb6_rpm_installer_photon3
+      - test_functionality_gpdb6_rpm_photon3
+      - create_gpdb6_deb_installer_ubuntu18.04
+      - test_functionality_gpdb6_deb_ubuntu18.04
+      - create_gpdb6_rpm_installer_centos6_oss
+      - create_gpdb6_rpm_installer_centos7_oss
+      - create_gpdb6_deb_ppa_installer_ubuntu18.04
+      - create_gpdb6_rpm_installer_rhel8_oss
+      - gpdb_component_packaging_centos6
+      - gpdb_component_packaging_centos7
+      - gpdb_component_packaging_rhel8
+      - gpdb_component_packaging_ubuntu18.04
+      - gpdb_component_packaging_photon3
+      - refresh_integrated_components
+    name: gpdb 6 server
+  - jobs:
+      - create_gpdb6_clients_rpm_installer_sles12
+      - test_functionality_clients_gpdb6_rpm_sles12
+      - create_gpdb6_clients_rpm_installer_centos6
+      - test_functionality_clients_gpdb6_rpm_centos6
+      - create_gpdb6_clients_rpm_installer_centos7
+      - test_functionality_clients_gpdb6_rpm_centos7
+      - create_gpdb6_clients_rpm_installer_rhel8
+      - test_functionality_clients_gpdb6_rpm_rhel8
+      - create_gpdb6_clients_deb_installer_ubuntu18.04
+      - test_functionality_clients_gpdb6_deb_ubuntu18.04
+    name: gpdb 6 client
+  - jobs:
+      - create_gpdb7_rpm_installer_rhel8
+      - test_functionality_gpdb7_rpm_rhel8
+      - create_gpdb7_rpm_installer_rhel8_oss
+      - create_gpdb7_rpm_installer_rocky8
+      - test_functionality_gpdb7_rpm_rocky8
+      - create_gpdb7_rpm_installer_rocky8_oss
+    name: gpdb 7 server
+  - jobs:
+      - create_gpdb7_clients_rpm_installer_rhel8
+      - test_functionality_clients_gpdb7_rpm_rhel8
+      - create_gpdb7_clients_rpm_installer_rocky8
+      - test_functionality_clients_gpdb7_rpm_rocky8
+    name: gpdb 7 client


### PR DESCRIPTION
The 'dev' image for 'start-release-process' is needed for the 'gpdb-package-testing' dev pipeline.

This commit changes the make file to use a new template file called 'gpdb-package-testing-devel' in order to produce the 'gpdb-package-testing-dev' with the only difference between it and 'gpdb-package-testing' template being that it retrieves the 'dev' image of 'start-release-process'.

[GPR-1109]

Authored-by: Lucas Bonner <blucas@vmware.com>