### PR TITLE
Fix for the test_functionality_gpdb6_rpm_rhel8 

### DIFF
--- a/ci/concourse/tests/gpdb6/server/install/controls/gpdb6-server-install.rb
+++ b/ci/concourse/tests/gpdb6/server/install/controls/gpdb6-server-install.rb
@@ -94,9 +94,9 @@ control 'Category:server-installs' do
   version = os.release
   if os.redhat?
     describe command("find /usr/local/greenplum-db/ -name *.pyc | grep -v python3.9|  wc -l") do
-      # rhel8 has a different python2 version: 2.7.17
+      # rhel8 has a different python2 version: 2.7.18
       if version =~ /^8/
-        its('stdout') { should eq "793\n" }
+        its('stdout') { should eq "794\n" }
       # rhel6 and rhel7 has python2 version: 2.7.12
       else
         its('stdout') { should eq "795\n" }


### PR DESCRIPTION
Upgraded from Python 2.7.17 to 2.7.18 & therefore also need a test change

Authored-by: Lucas Bonner <blucas@vmware.com>