### PR TITLE
verify_gpdb_versions.bash to support gpdb7

### DIFF
--- a/ci/concourse/scripts/verify_gpdb_versions.bash
+++ b/ci/concourse/scripts/verify_gpdb_versions.bash
@@ -23,8 +23,10 @@ assert_postgres_version_matches() {
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel
 
 for bin_gpdb in bin_gpdb_{centos{6,7},ubuntu18.04,rhel8}; do
-	install_greenplum "$bin_gpdb" "${GREENPLUM_INSTALL_DIR}"
-	assert_postgres_version_matches "$GPDB_SRC_SHA" "${GREENPLUM_INSTALL_DIR}"
+	if [ -d "$bin_gpdb" ]; then
+		install_greenplum "$bin_gpdb" "${GREENPLUM_INSTALL_DIR}"
+		assert_postgres_version_matches "$GPDB_SRC_SHA" "${GREENPLUM_INSTALL_DIR}"
+	fi
 done
 
 echo "Release Candidate SHA: ${GPDB_SRC_SHA}"


### PR DESCRIPTION
for gpdb7, it only has the dir bin_gpdb_rhel8, so need to test if the dir exist

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>