### PR TITLE
Fix subscription-manager register failure

### DIFF
--- a/ci/concourse/scripts/test-package-dependencies.bash
+++ b/ci/concourse/scripts/test-package-dependencies.bash
@@ -16,7 +16,7 @@ if [[ $PLATFORM == "rhel"* || $PLATFORM == "rocky"* || $PLATFORM == "oel"* ]]; t
 	if [[ $PLATFORM == "rhel8" ]]; then
 		dnf update -y && dnf install -y subscription-manager
 		rm /etc/rhsm-host
-		subscription-manager register --org=${REDHAT_SUBSCRIPTION_ORG_ID} --activationkey=${REDHAT_SUBSCRIPTION_KEY_ID}
+		subscription-manager register --org=${REDHAT_SUBSCRIPTION_ORG_ID} --activationkey=${REDHAT_SUBSCRIPTION_KEY_ID} || true
 		subscription-manager attach --auto
 		# Required to install *-devel pacakges.
 		subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
subscription-manager register will fail with 1, and it cause subscription-manager attach not run. the failure does not matter, since it is just unsubscrip status like following, after subscription-manager attach it will be subscip status.

The system has been registered with ID: XXXX
The registered system name is: XXXX
Installed Product Current Status:
Product Name: Red Hat Enterprise Linux for x86_64
Status:       Not Subscribed

[GPR-1174]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>