### PR TITLE
Update GPDB7 OSS release pipeline

### DIFF
--- a/ci/concourse/oss/rpmbuild.py
+++ b/ci/concourse/oss/rpmbuild.py
@@ -89,10 +89,14 @@ class RPMPackageBuilder(BasePackageBuilder):
 
     @property
     def rpm_package_name(self):
-        if self.is_oss:
-            return "open-source-greenplum-db-%s-%s-x86_64.rpm" % (self.gpdb_version_short, self.platform)
+        if self.platform == "rhel8" or self.platform == "rocky8" or self.platform == "oel8":
+            platform = "el8"
         else:
-            return "greenplum-db-%s-%s-x86_64.rpm" % (self.gpdb_version_short, self.platform)
+            platform = self.platform
+        if self.is_oss:
+            return "open-source-greenplum-db-%s-%s-x86_64.rpm" % (self.gpdb_version_short, platform)
+        else:
+            return "greenplum-db-%s-%s-x86_64.rpm" % (self.gpdb_version_short, platform)
 
     def _prepare_rpm_build_dir(self):
         for sub_dir in ["SOURCES", "SPECS","BUILD","RPMS"]:

--- a/ci/concourse/pipelines/gpdb-package-testing.yml
+++ b/ci/concourse/pipelines/gpdb-package-testing.yml
@@ -179,12 +179,12 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: clients/published/gpdb6/clients-rc-(.*)-sles12_x86_64.tar.gz
 
-- name: bin_gpdb7_clients_rhel8
+- name: bin_gpdb7_clients_rocky8
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: clients/published/main/clients-rc-(.*)-rhel8_x86_64.tar.gz
+    regexp: clients/published/main/clients-rc-(.*)-el8_x86_64.tar.gz
 
 - name: rpm_gpdb5_centos7
   type: gcs
@@ -244,13 +244,6 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: ((pipeline-name))/rpm_gpdb_clients_rhel8/gpdb6/greenplum-db-clients-0.0.0-rhel8-x86_64.rpm
 
-- name: rpm_gpdb7_clients_rhel8
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_clients_rhel8/main/greenplum-db-clients-0.0.0-rhel8-x86_64.rpm
-
 - name: rpm_gpdb6_clients_rocky8
   type: gcs
   source:
@@ -263,14 +256,7 @@ resources:
   source:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_clients_rocky8/main/greenplum-db-clients-0.0.0-rocky8-x86_64.rpm
-
-- name: rpm_gpdb7_clients_oel8
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_clients_oel8/main/greenplum-db-clients-0.0.0-oel8-x86_64.rpm
+    versioned_file: ((pipeline-name))/rpm_gpdb_clients_rocky8/main/greenplum-db-clients-0.0.0-el8-x86_64.rpm
 
 - name: rpm_gpdb6_clients_sles12
   type: gcs
@@ -351,26 +337,12 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.tar.gz
 
-- name: bin_gpdb7_rhel8
-  type: gcs
-  source:
-    bucket: pivotal-gpdb-concourse-resources-prod
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rhel8_x86_64.tar.gz
-
 - name: bin_gpdb7_rocky8
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rocky8_x86_64.tar.gz
-
-- name: bin_gpdb7_oel8
-  type: gcs
-  source:
-    bucket: pivotal-gpdb-concourse-resources-prod
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-oel8_x86_64.tar.gz
+    regexp: server/published/main/server-rc-(.*)-el8_x86_64.tar.gz
 
 - name: bin_gpdb6_photon3
   type: gcs
@@ -447,14 +419,6 @@ resources:
     password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
     tag: latest
 
-- name: gpdb7-rhel8-build
-  type: registry-image
-  source:
-    repository: gcr.io/data-gpdb-private-images/gpdb7-rhel8-build
-    username: _json_key
-    password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
-    tag: latest
-
 - name: gpdb6-rocky8-build
   type: registry-image
   source:
@@ -465,12 +429,6 @@ resources:
   type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb7-rocky8-build
-    tag: latest
-
-- name: gpdb7-oel8-build
-  type: registry-image
-  source:
-    repository: gcr.io/data-gpdb-public-images/gpdb7-oel8-build
     tag: latest
 
 - name: gpdb6-rhel8-test
@@ -652,26 +610,12 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: ((pipeline-name))/rpm_gpdb_oel7/gpdb6/open-source-greenplum-db-6-oel7-x86_64.rpm
 
-- name: rpm_gpdb7_rhel8_oss
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb7/open-source-greenplum-db-7-rhel8-x86_64.rpm
-
 - name: rpm_gpdb7_rocky8_oss
   type: gcs
   source:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_rocky8/gpdb7/open-source-greenplum-db-7-rocky8-x86_64.rpm
-
-- name: rpm_gpdb7_oel8_oss
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_oel8/gpdb7/open-source-greenplum-db-7-oel8-x86_64.rpm
+    versioned_file: ((pipeline-name))/rpm_gpdb_rocky8/gpdb7/open-source-greenplum-db-7-el8-x86_64.rpm
 
 - name: rpm_gpdb6_rhel8
   type: gcs
@@ -679,13 +623,6 @@ resources:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb6/greenplum-db-6-rhel8-x86_64.rpm
-
-- name: rpm_gpdb7_rhel8
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_rhel8/gpdb7/greenplum-db-7-rhel8-x86_64.rpm
 
 - name: rpm_gpdb6_rocky8
   type: gcs
@@ -699,14 +636,8 @@ resources:
   source:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_rocky8/gpdb7/greenplum-db-7-rocky8-x86_64.rpm
+    versioned_file: ((pipeline-name))/rpm_gpdb_rocky8/gpdb7/greenplum-db-7-el8-x86_64.rpm
 
-- name: rpm_gpdb7_oel8
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: ((pipeline-name))/rpm_gpdb_oel8/gpdb7/greenplum-db-7-oel8-x86_64.rpm
 
 - name: rpm_gpdb6_photon3
   type: gcs
@@ -2253,34 +2184,6 @@ jobs:
     params:
       PLATFORM: sles12
 
-- name: create_gpdb7_rpm_installer_rhel8_oss
-  plan:
-  - in_parallel:
-    - get: greenplum-database-release
-      trigger: true
-    - get: bin_gpdb7_rhel8
-      trigger: true
-    - get: gpdb7-rhel8-build
-    - get: gpdb6-osl
-  - task: retrieve_gpdb7_src
-    file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
-    image: gpdb7-rhel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_rhel8
-  - task: build_rpm_gpdb7_rhel8
-    file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
-    image: gpdb7-rhel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_rhel8
-      license_file: gpdb6-osl
-    params:
-      <<: *gpdb7-rpm-params-oss
-      PLATFORM: rhel8
-      GPDB_NAME: greenplum-db-7
-  - put: rpm_gpdb7_rhel8_oss
-    params:
-      file: gpdb_rpm_installer/*.rpm
-
 - name: create_gpdb7_rpm_installer_rocky8_oss
   plan:
   - in_parallel:
@@ -2306,61 +2209,6 @@ jobs:
       PLATFORM: rocky8
       GPDB_NAME: greenplum-db-7
   - put: rpm_gpdb7_rocky8_oss
-    params:
-      file: gpdb_rpm_installer/*.rpm
-
-- name: create_gpdb7_rpm_installer_oel8_oss
-  plan:
-  - in_parallel:
-    - get: greenplum-database-release
-      trigger: true
-    - get: bin_gpdb7_oel8
-      trigger: true
-    - get: gpdb7-oel8-build
-    - get: gpdb6-osl
-  - task: retrieve_gpdb7_src
-    file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
-    image: gpdb7-oel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_oel8
-  - task: build_rpm_gpdb7_oel8
-    file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
-    image: gpdb7-oel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_oel8
-      license_file: gpdb6-osl
-    params:
-      <<: *gpdb7-rpm-params-oss
-      PLATFORM: oel8
-      GPDB_NAME: greenplum-db-7
-  - put: rpm_gpdb7_oel8_oss
-    params:
-      file: gpdb_rpm_installer/*.rpm
-
-- name: create_gpdb7_rpm_installer_rhel8
-  plan:
-  - in_parallel:
-    - get: bin_gpdb7_rhel8
-      trigger: true
-    - get: greenplum-database-release
-      trigger: true
-    - get: gpdb7-rhel8-build
-    - get: gpdb6-osl
-  - task: retrieve_gpdb7_src
-    file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
-    image: gpdb7-rhel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_rhel8
-  - task: build_rpm_gpdb7_rhel8
-    file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
-    image: gpdb7-rhel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_rhel8
-      license_file: gpdb6-osl
-    params:
-      <<: *gpdb7-rpm-params
-      PLATFORM: rhel8
-  - put: rpm_gpdb7_rhel8
     params:
       file: gpdb_rpm_installer/*.rpm
 
@@ -2391,60 +2239,10 @@ jobs:
     params:
       file: gpdb_rpm_installer/*.rpm
 
-- name: create_gpdb7_rpm_installer_oel8
-  plan:
-  - in_parallel:
-    - get: bin_gpdb7_oel8
-      trigger: true
-    - get: greenplum-database-release
-      trigger: true
-    - get: gpdb7-oel8-build
-    - get: gpdb6-osl
-  - task: retrieve_gpdb7_src
-    file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
-    image: gpdb7-oel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_oel8
-  - task: build_rpm_gpdb7_oel8
-    file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
-    image: gpdb7-oel8-build
-    input_mapping:
-      bin_gpdb: bin_gpdb7_oel8
-      license_file: gpdb6-osl
-    params:
-      <<: *gpdb7-rpm-params
-      PLATFORM: oel8
-  - put: rpm_gpdb7_oel8
-    params:
-      file: gpdb_rpm_installer/*.rpm
-
-- name: create_gpdb7_clients_rpm_installer_rhel8
-  plan:
-  - in_parallel:
-    - get: bin_gpdb7_clients_rhel8
-      trigger: true
-    - get: gpdb7-rhel8-build
-    - get: greenplum-database-release
-      trigger: true
-  - in_parallel:
-    - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
-      image: gpdb7-rhel8-build
-      input_mapping:
-        bin_gpdb_clients: bin_gpdb7_clients_rhel8
-      params:
-        GPDB_VERSION: 0.0.0
-        PLATFORM: rhel8
-        GPDB_MAJOR_VERSION: "7"
-      task: build_rpm_gpdb_rhel8
-  - in_parallel:
-    - params:
-        file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rhel8-x86_64.rpm
-      put: rpm_gpdb7_clients_rhel8
-
 - name: create_gpdb7_clients_rpm_installer_rocky8
   plan:
   - in_parallel:
-    - get: bin_gpdb7_clients_rhel8
+    - get: bin_gpdb7_clients_rocky8
       trigger: true
     - get: gpdb7-rocky8-build
     - get: greenplum-database-release
@@ -2453,7 +2251,7 @@ jobs:
     - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
       image: gpdb7-rocky8-build
       input_mapping:
-        bin_gpdb_clients: bin_gpdb7_clients_rhel8
+        bin_gpdb_clients: bin_gpdb7_clients_rocky8
       params:
         GPDB_VERSION: 0.0.0
         PLATFORM: rocky8
@@ -2461,51 +2259,28 @@ jobs:
       task: build_rpm_gpdb_rocky8
   - in_parallel:
     - params:
-        file: gpdb_clients_rpm_installer/greenplum-db-clients-*-rocky8-x86_64.rpm
+        file: gpdb_clients_rpm_installer/greenplum-db-clients-*-el8-x86_64.rpm
       put: rpm_gpdb7_clients_rocky8
-
-- name: create_gpdb7_clients_rpm_installer_oel8
-  plan:
-  - in_parallel:
-    - get: bin_gpdb7_clients_rhel8
-      trigger: true
-    - get: gpdb7-oel8-build
-    - get: greenplum-database-release
-      trigger: true
-  - in_parallel:
-    - file: greenplum-database-release/ci/concourse/tasks/build-gpdb-clients-rpm.yml
-      image: gpdb7-oel8-build
-      input_mapping:
-        bin_gpdb_clients: bin_gpdb7_clients_rhel8
-      params:
-        GPDB_VERSION: 0.0.0
-        PLATFORM: oel8
-        GPDB_MAJOR_VERSION: "7"
-      task: build_rpm_gpdb_oel8
-  - in_parallel:
-    - params:
-        file: gpdb_clients_rpm_installer/greenplum-db-clients-*-oel8-x86_64.rpm
-      put: rpm_gpdb7_clients_oel8
 
 - name: test_functionality_gpdb7_rpm_rhel8
   plan:
   - in_parallel:
-    - get: rpm_gpdb7_rhel8
+    - get: rpm_gpdb7_rocky8
       passed:
-      - create_gpdb7_rpm_installer_rhel8
+      - create_gpdb7_rpm_installer_rocky8
       trigger: true
     - get: greenplum-database-release
       passed:
-      - create_gpdb7_rpm_installer_rhel8
+      - create_gpdb7_rpm_installer_rocky8
     - get: gpdb7-rhel8-test
     - get: rhel-8
     - get: previous-6-oss-release
       params:
         globs:
         - open-source-greenplum-db-*-rhel8-x86_64.rpm
-    - get: rpm_gpdb7_rhel8_oss
+    - get: rpm_gpdb7_rocky8_oss
       passed:
-      - create_gpdb7_rpm_installer_rhel8_oss
+      - create_gpdb7_rpm_installer_rocky8_oss
       trigger: true
     - get: previous-6.20.0-release
       params:
@@ -2516,8 +2291,8 @@ jobs:
       file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
       image: gpdb7-rhel8-test
       input_mapping:
-        gpdb_rpm_installer: rpm_gpdb7_rhel8
-        gpdb_rpm_oss_installer: rpm_gpdb7_rhel8_oss
+        gpdb_rpm_installer: rpm_gpdb7_rocky8
+        gpdb_rpm_oss_installer: rpm_gpdb7_rocky8_oss
       params:
         PLATFORM: rhel8
         GPDB_MAJOR_VERSION: "7"
@@ -2525,7 +2300,7 @@ jobs:
       file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
       image: rhel-8
       input_mapping:
-        gpdb_pkg_installer: rpm_gpdb7_rhel8
+        gpdb_pkg_installer: rpm_gpdb7_rocky8
       params:
         PLATFORM: rhel8
         GPDB_MAJOR_VERSION: "7"
@@ -2570,26 +2345,26 @@ jobs:
 - name: test_functionality_gpdb7_rpm_oel8
   plan:
   - in_parallel:
-    - get: rpm_gpdb7_oel8
+    - get: rpm_gpdb7_rocky8
       passed:
-      - create_gpdb7_rpm_installer_oel8
+      - create_gpdb7_rpm_installer_rocky8
       trigger: true
     - get: greenplum-database-release
       passed:
-      - create_gpdb7_rpm_installer_oel8
+      - create_gpdb7_rpm_installer_rocky8
     - get: gpdb7-oel8-test
     - get: oracle-8
-    - get: rpm_gpdb7_oel8_oss
+    - get: rpm_gpdb7_rocky8_oss
       passed:
-      - create_gpdb7_rpm_installer_oel8_oss
+      - create_gpdb7_rpm_installer_rocky8_oss
       trigger: true
   - in_parallel:
     - task: test_gpdb7_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
       image: gpdb7-oel8-test
       input_mapping:
-        gpdb_rpm_installer: rpm_gpdb7_oel8
-        gpdb_rpm_oss_installer: rpm_gpdb7_oel8_oss
+        gpdb_rpm_installer: rpm_gpdb7_rocky8
+        gpdb_rpm_oss_installer: rpm_gpdb7_rocky8_oss
       params:
         PLATFORM: oel8
         GPDB_MAJOR_VERSION: "7"
@@ -2597,7 +2372,7 @@ jobs:
       file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
       image: oracle-8
       input_mapping:
-        gpdb_pkg_installer: rpm_gpdb7_oel8
+        gpdb_pkg_installer: rpm_gpdb7_rocky8
       params:
         PLATFORM: oel8
         GPDB_MAJOR_VERSION: "7"
@@ -2605,24 +2380,24 @@ jobs:
 - name: test_functionality_clients_gpdb7_rpm_rhel8
   plan:
   - in_parallel:
-    - get: rpm_gpdb7_clients_rhel8
+    - get: rpm_gpdb7_clients_rocky8
       passed:
-      - create_gpdb7_clients_rpm_installer_rhel8
+      - create_gpdb7_clients_rpm_installer_rocky8
       trigger: true
-    - get: gpdb7-rhel8-build
+    - get: gpdb7-rhel8-test
     - get: greenplum-database-release
       passed:
-      - create_gpdb7_clients_rpm_installer_rhel8
+      - create_gpdb7_clients_rpm_installer_rocky8
     - get: rhel-8
-    - get: rpm_gpdb7_rhel8_oss
+    - get: rpm_gpdb7_rocky8_oss
       passed:
-      - create_gpdb7_rpm_installer_rhel8_oss
+      - create_gpdb7_rpm_installer_rocky8_oss
   - in_parallel:
     - task: test_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
-      image: gpdb7-rhel8-build
+      image: gpdb7-rhel8-test
       input_mapping:
-        gpdb_clients_package_installer: rpm_gpdb7_clients_rhel8
+        gpdb_clients_package_installer: rpm_gpdb7_clients_rocky8
       params:
         PLATFORM: rhel8
         GPDB_MAJOR_VERSION: "7"
@@ -2630,7 +2405,7 @@ jobs:
       file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
       image: rhel-8
       input_mapping:
-        gpdb_pkg_installer: rpm_gpdb7_clients_rhel8
+        gpdb_pkg_installer: rpm_gpdb7_clients_rocky8
       params:
         PLATFORM: rhel8
         GPDB_MAJOR_VERSION: "7"
@@ -2675,24 +2450,24 @@ jobs:
 - name: test_functionality_clients_gpdb7_rpm_oel8
   plan:
   - in_parallel:
-    - get: rpm_gpdb7_clients_oel8
+    - get: rpm_gpdb7_clients_rocky8
       passed:
-      - create_gpdb7_clients_rpm_installer_oel8
+      - create_gpdb7_clients_rpm_installer_rocky8
       trigger: true
-    - get: gpdb7-oel8-build
+    - get: gpdb7-oel8-test
     - get: greenplum-database-release
       passed:
-      - create_gpdb7_clients_rpm_installer_oel8
+      - create_gpdb7_clients_rpm_installer_rocky8
     - get: oracle-8
-    - get: rpm_gpdb7_oel8_oss
+    - get: rpm_gpdb7_rocky8_oss
       passed:
-      - create_gpdb7_rpm_installer_oel8_oss
+      - create_gpdb7_rpm_installer_rocky8_oss
   - in_parallel:
     - task: test_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-clients-functionality.yml
-      image: gpdb7-oel8-build
+      image: gpdb7-oel8-test
       input_mapping:
-        gpdb_clients_package_installer: rpm_gpdb7_clients_oel8
+        gpdb_clients_package_installer: rpm_gpdb7_clients_rocky8
       params:
         PLATFORM: oel8
         GPDB_MAJOR_VERSION: "7"
@@ -2700,7 +2475,7 @@ jobs:
       file: greenplum-database-release/ci/concourse/tasks/test-package-dependencies.yml
       image: oracle-8
       input_mapping:
-        gpdb_pkg_installer: rpm_gpdb7_clients_oel8
+        gpdb_pkg_installer: rpm_gpdb7_clients_rocky8
       params:
         PLATFORM: oel8
         GPDB_MAJOR_VERSION: "7"
@@ -2747,22 +2522,16 @@ groups:
   - create_gpdb6_rpm_installer_centos6_oss
   - create_gpdb6_rpm_installer_centos7_oss
   - create_gpdb6_rpm_installer_oel7_oss
-  - create_gpdb7_clients_rpm_installer_rhel8
   - create_gpdb7_clients_rpm_installer_rocky8
-  - create_gpdb7_clients_rpm_installer_oel8
   - test_functionality_clients_gpdb7_rpm_rhel8
   - test_functionality_clients_gpdb7_rpm_rocky8
   - test_functionality_clients_gpdb7_rpm_oel8
-  - create_gpdb7_rpm_installer_rhel8
   - create_gpdb7_rpm_installer_rocky8
-  - create_gpdb7_rpm_installer_oel8
   - test_functionality_gpdb7_rpm_rhel8
   - test_functionality_gpdb7_rpm_rocky8
   - test_functionality_gpdb7_rpm_oel8
   - create_gpdb6_rpm_installer_rhel8_oss
-  - create_gpdb7_rpm_installer_rhel8_oss
   - create_gpdb7_rpm_installer_rocky8_oss
-  - create_gpdb7_rpm_installer_oel8_oss
   - gpdb_component_packaging_centos6
   - gpdb_component_packaging_centos7
   - gpdb_component_packaging_rhel8
@@ -2824,21 +2593,15 @@ groups:
   - test_functionality_clients_gpdb6_deb_ubuntu18.04
   name: gpdb 6 client
 - jobs:
-  - create_gpdb7_rpm_installer_rhel8
-  - test_functionality_gpdb7_rpm_rhel8
-  - create_gpdb7_rpm_installer_rhel8_oss
   - create_gpdb7_rpm_installer_rocky8
-  - test_functionality_gpdb7_rpm_rocky8
   - create_gpdb7_rpm_installer_rocky8_oss
-  - create_gpdb7_rpm_installer_oel8
+  - test_functionality_gpdb7_rpm_rocky8
+  - test_functionality_gpdb7_rpm_rhel8
   - test_functionality_gpdb7_rpm_oel8
-  - create_gpdb7_rpm_installer_oel8_oss
   name: gpdb 7 server
 - jobs:
-  - create_gpdb7_clients_rpm_installer_rhel8
-  - test_functionality_clients_gpdb7_rpm_rhel8
   - create_gpdb7_clients_rpm_installer_rocky8
   - test_functionality_clients_gpdb7_rpm_rocky8
-  - create_gpdb7_clients_rpm_installer_oel8
   - test_functionality_clients_gpdb7_rpm_oel8
+  - test_functionality_clients_gpdb7_rpm_rhel8
   name: gpdb 7 client

--- a/ci/concourse/pipelines/gpdb7-opensource-release.yml
+++ b/ci/concourse/pipelines/gpdb7-opensource-release.yml
@@ -45,14 +45,12 @@ resources:
     url: ((resources/slack/prod/slack-alert-general-webhook))
 
 ## Image Resources
-- name: gpdb7-rhel8-build
+- name: gpdb7-rocky8-build
   type: registry-image
   icon: docker
   source:
-    repository: gcr.io/data-gpdb-private-images/gpdb7-rhel8-build
+    repository: gcr.io/data-gpdb-public-images/gpdb7-rocky8-build
     tag: latest
-    username: _json_key
-    password: ((resources/gcp/service_accounts/container-registry-readonly-service-account-key))
 
 - name: gpdb_src
   type: git
@@ -99,7 +97,7 @@ resources:
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((resources/gcp/service_accounts/concourse-gcs-resources-service-account-key))
-    regexp: oss/release-candidates/gpdb7/greenplum-db-oss-(((release-version)))-(.*)-(((commit-sha)).*)-rhel8.tar.gz
+    regexp: oss/release-candidates/gpdb7/greenplum-db-oss-(((release-version)))-(.*)-(((commit-sha)).*)-el8.tar.gz
 
 - name: bin_gpdb_rhel8_release
   type: gcs
@@ -107,7 +105,7 @@ resources:
   source:
     bucket: ((gcs-bucket-for-oss))
     json_key: ((resources/gcp/service_accounts/concourse-gcs-resources-service-account-key))
-    regexp: greenplum-oss-server/released/gpdb7/server-(.*)-rhel8_x86_64.tar.gz
+    regexp: greenplum-oss-server/released/gpdb7/server-(.*)-el8_x86_64.tar.gz
 
 - name: gpdb_rpm_installer_rhel8
   type: gcs
@@ -115,7 +113,7 @@ resources:
   source:
     bucket: ((gcs-bucket-for-oss))
     json_key: ((resources/gcp/service_accounts/concourse-gcs-resources-service-account-key))
-    regexp: greenplum-oss-server/released/gpdb7/open-source-greenplum-db-(.*)-rhel8-x86_64.rpm
+    regexp: greenplum-oss-server/released/gpdb7/open-source-greenplum-db-(.*)-el8-x86_64.rpm
 
 - name: pivotal-gpdb
   type: tanzunet
@@ -179,11 +177,11 @@ jobs:
       passed: [compilation-gate]
     - get: bin_gpdb_rhel8
       passed: [compilation-gate]
-    - get: gpdb7-rhel8-build
+    - get: gpdb7-rocky8-build
     - get: license_file
   - task: create_gpdb_rpm_package
     file: greenplum-database-release/ci/concourse/tasks/build-gpdb-rpm.yml
-    image: gpdb7-rhel8-build
+    image: gpdb7-rocky8-build
     input_mapping:
       bin_gpdb: bin_gpdb_rhel8
     params:
@@ -239,7 +237,7 @@ jobs:
         - -ec
         - |
           gpdb_semver=$(cat pivotal-gpdb/version |cut -d "#" -f 1)
-          cp -v bin_gpdb_rhel8/greenplum-db-oss-*.tar.gz releases/server-${gpdb_semver}-rhel8_x86_64.tar.gz
+          cp -v bin_gpdb_rhel8/greenplum-db-oss-*.tar.gz releases/server-${gpdb_semver}-el8_x86_64.tar.gz
   - task: verify_gpdb_versions
     config:
       platform: linux
@@ -274,7 +272,7 @@ jobs:
   - in_parallel:
     - put: bin_gpdb_rhel8_release
       params:
-        file: "releases/server-*rhel8*.tar.gz"
+        file: "releases/server-*el8*.tar.gz"
 
 - name: publish_gpdb_github_release
   on_failure:

--- a/ci/concourse/scripts/build-gpdb-clients-rpm.sh
+++ b/ci/concourse/scripts/build-gpdb-clients-rpm.sh
@@ -108,6 +108,7 @@ function _main() {
 	local __rpm_gpdb_clients_version
 	local __final_rpm_name
 	local __rpm_build_flags
+	local __platform
 
 	if [[ -z "${GPDB_VERSION}" ]]; then
 		set_gpdb_clients_version
@@ -122,7 +123,13 @@ function _main() {
 	echo "[INFO] GPDB version modified for rpm requirements: ${__rpm_gpdb_clients_version}"
 
 	# Build the expected rpm name based on the gpdb version of the artifacts
-	__final_rpm_name="greenplum-db-clients-${__gpdb_clients_version}-${PLATFORM}-x86_64.rpm"
+	__platform="${PLATFORM}"
+	case "${__platform}" in
+	rhel8*) __final_rpm_name="greenplum-db-clients-${__gpdb_clients_version}-el8-x86_64.rpm" ;;
+	rocky8*) __final_rpm_name="greenplum-db-clients-${__gpdb_clients_version}-el8-x86_64.rpm" ;;
+	oel8*) __final_rpm_name="greenplum-db-clients-${__gpdb_clients_version}-el8-x86_64.rpm" ;;
+	*) __final_rpm_name="greenplum-db-clients-${__gpdb_clients_version}-${PLATFORM}-x86_64.rpm" ;;
+	esac
 	echo "[INFO] Final RPM name: ${__final_rpm_name}"
 
 	# Conventional location to build RPMs is platform specific

--- a/ci/concourse/scripts/test-clients-functionality.sh
+++ b/ci/concourse/scripts/test-clients-functionality.sh
@@ -3,8 +3,12 @@
 set -exo pipefail
 
 export GPDB_CLIENTS_PATH="gpdb_clients_package_installer"
-export GPDB_CLIENTS_ARCH="$PLATFORM"
 export GPDB_CLIENTS_VERSION="0.0.0"
+if [[ $PLATFORM == "rhel8"* || $PLATFORM == "rocky8"* || $PLATFORM == "oel8"* ]]; then
+	export GPDB_CLIENTS_ARCH="el8"
+else
+	export GPDB_CLIENTS_ARCH="$PLATFORM"
+fi
 
 if [[ $PLATFORM == "rhel"* || $PLATFORM == "sles"* || $PLATFORM == "rocky"* || $PLATFORM == "oel"* ]]; then
 

--- a/ci/concourse/scripts/test-functionality-rpm.bash
+++ b/ci/concourse/scripts/test-functionality-rpm.bash
@@ -11,7 +11,11 @@ set -exo pipefail
 
 export GPDB_RPM_PATH="gpdb_rpm_installer"
 export GPDB_RPM_OSS_PATH="gpdb_rpm_oss_installer"
-export GPDB_RPM_ARCH=$PLATFORM
+if [[ $PLATFORM == "rhel8"* || $PLATFORM == "rocky8"* || $PLATFORM == "oel8"* ]]; then
+	export GPDB_RPM_ARCH="el8"
+else
+	export GPDB_RPM_ARCH="$PLATFORM"
+fi
 # oel7 does not have previous released rpm, so it use rhel7 as previous release rpm
 if [[ $PLATFORM == "oel7" ]]; then
 	for dir in previous-6*; do

--- a/ci/concourse/tests/gpdb7/server/upgrade/controls/gpdb7-server-upgrade.rb
+++ b/ci/concourse/tests/gpdb7/server/upgrade/controls/gpdb7-server-upgrade.rb
@@ -24,7 +24,7 @@ control 'RPM with GPDB 6' do
   title 'when both greenplum-db version 6.20.0 and greenplum-db-7 are installed.'
   # Previous 6 release not yet available for Photon and rocky
   if os.redhat? && os.name != 'rocky'
-    describe command("yum install -y previous-6.20.0-release/greenplum-db-#{previous_6_version}-#{gpdb_rpm_arch}-x86_64.rpm") do
+    describe command("yum install -y previous-6.20.0-release/greenplum-db-#{previous_6_version}-*-x86_64.rpm") do
       its('exit_status') { should eq 0 }
     end
 


### PR DESCRIPTION
For greenplum-database-release-7 pipeline:
- replace gpdb7-rhel8-build with gpdb7-rocky8-build image, and change the file name from rhel8 to el8

For gpdb-package-testing pipeline:
- remove the job create_gpdb7_rpm_installer_oel8 and create_gpdb7_rpm_installer_rhel8
- remove the job create_gpdb7_rpm_installer_oel8_oss and create_gpdb7_rpm_installer_rhel8_oss
- remove the job create_gpdb7_clients_rpm_installer_oel8 and create_gpdb7_clients_rpm_installer_rhel8
- update the resource bin_gpdb7_rocky8 and bin_gpdb7_clients_rocky8 file name to el8
- update the gpdb7 rpm file name to el8

[GPR-1228]

Authored-by: Ning Wu <ningw@vmware.com>