### PR TITLE
Add required package for resource group for GPDB6

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -64,13 +64,16 @@ Requires: libuuid
 %if "%{platform}" == "rhel8" || "%{platform}" == "rocky8" || "%{platform}" == "oel8"
 Requires: openssl-libs
 Requires: libevent
+Requires: libcgroup-tools
 %endif
 %if "%{platform}" == "rhel7" || "%{platform}" == "oel7"
 Requires: openssl-libs
 Requires: libevent
+Requires: libcgroup-tools
 %endif
 %if "%{platform}" == "rhel6"
 Requires: libevent2
+Requires: libcgroup
 %endif
 
 %if "%{platform}" == "photon3"


### PR DESCRIPTION
- libcgroup-tools will be required dependency on RHEL7/8
- libcgroup will be required dependency on RHEL6

[GPR-1193]

Authored-by: Ning Wu <ningw@vmware.com>