### PR TITLE
Add upgrade and conflict test for gpdb7

### DIFF
--- a/ci/concourse/pipelines/gpdb-package-testing.yml
+++ b/ci/concourse/pipelines/gpdb-package-testing.yml
@@ -274,6 +274,14 @@ resources:
     product_slug: vmware-tanzu-greenplum
     product_version: 6\.20\.0
 
+- name: previous-7.0.0-beta.0-release
+  type: tanzunet
+  source:
+    api_token: ((releng/public-tanzunet-refresh-token))
+    endpoint: ((tanzunet-endpoint))
+    product_slug: vmware-tanzu-greenplum
+    product_version: 7\.0\.0-beta\.0
+
 # the file is comming from https://concourse.releng.gpdb.pivotal.io/teams/main/pipelines/greenplum-database-release/jobs/publish_to_ppa/builds/11
 # it is 6.21.2 ppa deb package, manully updloaded to the following command
 # yamllint disable-line rule:line-length
@@ -292,6 +300,13 @@ resources:
     endpoint: ((tanzunet-endpoint))
     product_slug: greenplum-database
     product_version: 6\.20\.0
+
+- name: previous-7.0.0-beta.0-oss-release
+  type: github-release
+  source:
+    owner: greenplum-db
+    repository: gpdb
+    tag_filter: 7.0.0-beta.0
 
 - name: previous-5-release
   type: tanzunet
@@ -517,6 +532,13 @@ resources:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: osl/released/gpdb6/open_source_license_VMware_Tanzu_Greenplum_Database_(((gpdb6-osl-version-regex)))_GA.txt
+
+- name: gpdb7-osl
+  type: gcs
+  source:
+    bucket: pivotal-gpdb-concourse-resources-prod
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: osl/released/gpdb7/open_source_license_VMware_Tanzu_Greenplum_(((gpdb7-osl-version-regex))).txt
 
 - name: license_file
   type: gcs
@@ -2080,7 +2102,7 @@ jobs:
     - get: bin_gpdb7_rocky8
       trigger: true
     - get: gpdb7-rocky8-build
-    - get: gpdb6-osl
+    - get: gpdb7-osl
   - task: retrieve_gpdb7_src
     file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
     image: gpdb7-rocky8-build
@@ -2091,7 +2113,7 @@ jobs:
     image: gpdb7-rocky8-build
     input_mapping:
       bin_gpdb: bin_gpdb7_rocky8
-      license_file: gpdb6-osl
+      license_file: gpdb7-osl
     params:
       <<: *gpdb7-rpm-params-oss
       PLATFORM: rocky8
@@ -2108,7 +2130,7 @@ jobs:
     - get: greenplum-database-release
       trigger: true
     - get: gpdb7-rocky8-build
-    - get: gpdb6-osl
+    - get: gpdb7-osl
   - task: retrieve_gpdb7_src
     file: greenplum-database-release/ci/concourse/tasks/retrieve-gpdb-src.yml
     image: gpdb7-rocky8-build
@@ -2119,7 +2141,7 @@ jobs:
     image: gpdb7-rocky8-build
     input_mapping:
       bin_gpdb: bin_gpdb7_rocky8
-      license_file: gpdb6-osl
+      license_file: gpdb7-osl
     params:
       <<: *gpdb7-rpm-params
       PLATFORM: rocky8
@@ -2162,7 +2184,7 @@ jobs:
       - create_gpdb7_rpm_installer_rocky8
     - get: gpdb7-rhel8-test
     - get: rhel-8
-    - get: previous-6-oss-release
+    - get: previous-7.0.0-beta.0-oss-release
       params:
         globs:
         - open-source-greenplum-db-*-rhel8-x86_64.rpm
@@ -2171,6 +2193,10 @@ jobs:
       - create_gpdb7_rpm_installer_rocky8_oss
       trigger: true
     - get: previous-6.20.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
+    - get: previous-7.0.0-beta.0-release
       params:
         globs:
         - greenplum-db-*-rhel8-x86_64.rpm
@@ -2211,6 +2237,18 @@ jobs:
       passed:
       - create_gpdb7_rpm_installer_rocky8_oss
       trigger: true
+    - get: previous-7.0.0-beta.0-oss-release
+      params:
+        globs:
+        - open-source-greenplum-db-*-rhel8-x86_64.rpm
+    - get: previous-6.20.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
+    - get: previous-7.0.0-beta.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
   - in_parallel:
     - task: test_gpdb7_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml
@@ -2246,6 +2284,18 @@ jobs:
       passed:
       - create_gpdb7_rpm_installer_rocky8_oss
       trigger: true
+    - get: previous-7.0.0-beta.0-oss-release
+      params:
+        globs:
+        - open-source-greenplum-db-*-rhel8-x86_64.rpm
+    - get: previous-6.20.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
+    - get: previous-7.0.0-beta.0-release
+      params:
+        globs:
+        - greenplum-db-*-rhel8-x86_64.rpm
   - in_parallel:
     - task: test_gpdb7_rpm_functionality
       file: greenplum-database-release/ci/concourse/tasks/test-functionality-rpm.yml

--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -11,6 +11,7 @@
 # the License.
 
 %define _build_id_links none
+%{!?gpdb_major_version:%global gpdb_major_version 7}
 
 # Disable automatic dependency processing both for requirements and provides
 AutoReqProv: no

--- a/ci/concourse/scripts/test-functionality-rpm.bash
+++ b/ci/concourse/scripts/test-functionality-rpm.bash
@@ -92,10 +92,7 @@ elif [[ $GPDB_MAJOR_VERSION == "7" ]]; then
 		inspec exec ${test_prefix}/conflicts --reporter documentation --no-distinct-exit --no-backend-cache
 		inspec exec ${test_prefix}/install --reporter documentation --no-distinct-exit --no-backend-cache
 		inspec exec ${test_prefix}/remove --reporter documentation --no-backend-cache
-		# OEL8 has no previous RPM to test upgrade yet
-		if [[ $PLATFORM != "oel8" ]]; then
-			inspec exec ${test_prefix}/upgrade --reporter documentation --no-distinct-exit --no-backend-cache
-		fi
+		inspec exec ${test_prefix}/upgrade --reporter documentation --no-distinct-exit --no-backend-cache
 	else
 		echo "${PLATFORM} is not yet supported for Greenplum 7.X"
 		exit 1

--- a/ci/concourse/tasks/test-functionality-rpm.yml
+++ b/ci/concourse/tasks/test-functionality-rpm.yml
@@ -14,7 +14,11 @@ inputs:
   optional: true
 - name: previous-6.20.0-release
   optional: true
+- name: previous-7.0.0-beta.0-release
+  optional: true
 - name: previous-6-oss-release
+  optional: true
+- name: previous-7.0.0-beta.0-oss-release
   optional: true
 
 run:

--- a/ci/concourse/vars/gpdb-package-testing.dev.yml
+++ b/ci/concourse/vars/gpdb-package-testing.dev.yml
@@ -7,4 +7,5 @@ gpdb-stable-builds-bucket-name: gpdb-stable-concourse-builds-dev
 gcs-bucket-intermediates: pivotal-gpdb-concourse-resources-intermediates-dev
 tanzunet-endpoint: https://network.tanzu.vmware.com
 gpdb6-osl-version-regex: '6\.10\.0'
+gpdb7-osl-version-regex: '7\.0\.0-beta'
 gpdb5-osl-version-regex: '5\.18\.0\.0'

--- a/ci/concourse/vars/gpdb-package-testing.prod.yml
+++ b/ci/concourse/vars/gpdb-package-testing.prod.yml
@@ -7,4 +7,5 @@ gpdb-stable-builds-bucket-name: gpdb-stable-concourse-builds
 gcs-bucket-intermediates: pivotal-gpdb-concourse-resources-intermediates-prod
 tanzunet-endpoint: https://network.tanzu.vmware.com
 gpdb6-osl-version-regex: '6\.10\.0'
+gpdb7-osl-version-regex: '7\.0\.0-beta'
 gpdb5-osl-version-regex: '5\.18\.0\.0'


### PR DESCRIPTION
Fix the undefined var gpdb_major_version. It cause when upgrade gpdb7 from previous version, the link greenplum-db did not point to the new gpdb7 rpm version

When previous-7.0.0-beta.0-release installed, then intall current gpdb7 version rpm, it will automatically remove the 7.0.0-beta.0 rpm, and upgrade to current gpdb7 version rpm

When install previous-7.0.0-beta.0-oss-release first, then install current gpdb7 version rpm, it will conflict
When install previous-7.0.0-beta.0-release first, then install current gpdb7 oss version rpm, it will also confict

[GPR-1059]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>