### PR TITLE
Prevent create gpdb-package-testing-HEAD-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DEV_PIPELINE_7_NAME              = dev-greenplum-database-release-7-${BRANCH}-${
 FLY_CMD                    ?= fly
 FLY_OPTION_NON_INTERACTIVE ?=
 
-DEV_GPDB-PACKAGE-TESTING_PIPELINE_NAME = dev-gpdb-package-testing-${BRANCH}-${USER}
+DEV_GPDB_PACKAGE_TESTING_PIPELINE_NAME ?= dev-gpdb-package-testing-${BRANCH}-${USER}
 
 GOLANG_VERSION = 1.17.6
 
@@ -216,17 +216,17 @@ set-gpdb-package-testing-dev: generate-variables
 	$(FLY_CMD) --target=$(CONCOURSE) \
 	set-pipeline \
 	--check-creds \
-	--pipeline=gpdb-package-testing-$(BRANCH)-${USER} \
+	--pipeline=${DEV_GPDB_PACKAGE_TESTING_PIPELINE_NAME} \
 	--config=ci/concourse/pipelines/gpdb-package-testing-dev.yml \
 	--load-vars-from=${RELEASE_CONFIG} \
 	--load-vars-from=ci/concourse/vars/gpdb-package-testing.dev.yml \
 	--load-vars-from=ci/concourse/vars/greenplum-database-release.dev.yml \
 	--var=greenplum-database-release-git-branch=${BRANCH} \
-	--var=pipeline-name=${DEV_GPDB-PACKAGE-TESTING_PIPELINE_NAME} \
+	--var=pipeline-name=${DEV_GPDB_PACKAGE_TESTING_PIPELINE_NAME} \
 	--var=run_mode=dev \
 	$(FLY_OPTION_NON_INTERACTIVE)
 
-	$(FLY_CMD) --target=releng unpause-pipeline --pipeline=gpdb-package-testing-$(BRANCH)-${USER}
+	$(FLY_CMD) --target=releng unpause-pipeline --pipeline=${DEV_GPDB_PACKAGE_TESTING_PIPELINE_NAME}
 
 
 ## ----------------------------------------------------------------------

--- a/ci/concourse/pipelines/gpdb-package-testing.yml
+++ b/ci/concourse/pipelines/gpdb-package-testing.yml
@@ -936,6 +936,8 @@ jobs:
       params:
         BASIC_AUTH_PASSWORD: ((releng/basic_auth_password_releng))
         RUN_MODE: ((run_mode))
+        PIPELINE_NAME: ((pipeline-name))
+        BRANCH: ((greenplum-database-release-git-branch))
       run:
         path: /bin/sh
         args:
@@ -945,7 +947,8 @@ jobs:
           export WORKSPACE=`pwd`
           # RUN_MODE: prod|dev
           if [ "${RUN_MODE}" != "prod" ]; then
-            FLY_CMD="fly_7.8.3" FLY_OPTION_NON_INTERACTIVE="-n" make -C greenplum-database-release set-gpdb-package-testing-dev
+            FLY_CMD="fly_7.8.3" FLY_OPTION_NON_INTERACTIVE="-n" WORKSPACE=$(pwd) BRANCH=${BRANCH} \
+            DEV_GPDB_PACKAGE_TESTING_PIPELINE_NAME=${PIPELINE_NAME} make -C greenplum-database-release set-gpdb-package-testing-dev
             exit 0
           else
             FLY_CMD="fly_7.8.3" FLY_OPTION_NON_INTERACTIVE="-n" make -C greenplum-database-release set-gpdb-package-testing-prod


### PR DESCRIPTION
the gpdb-package-testing-HEAD-root is created when set dev pipeline for gpdb-package-testing, in concourse tasks, the branch and user name is settting to HEAD and root.
To prevent is being created, make DEV_GPDB_PACKAGE_TESTING_PIPELINE_NAME can be set by user if not set, so we can pass it when fly pipeline

[GPR-1282]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>