### PR TITLE
Fix the filename wrong when building rpm for gpdb6 on rhel8

### DIFF
--- a/ci/concourse/oss/rpmbuild.py
+++ b/ci/concourse/oss/rpmbuild.py
@@ -89,7 +89,7 @@ class RPMPackageBuilder(BasePackageBuilder):
 
     @property
     def rpm_package_name(self):
-        if self.platform == "rhel8" or self.platform == "rocky8" or self.platform == "oel8" and self.gpdb_version_short == "7":
+        if (self.platform == "rhel8" or self.platform == "rocky8" or self.platform == "oel8") and self.gpdb_version_short == "7":
             platform = "el8"
         else:
             platform = self.platform


### PR DESCRIPTION
For the three platforms rhel8, rocky8 and oel8, we want the name suffix to be rhel8 for gpdb6 and el8 for gpdb7, since the operator precedence in Python `and` has more higher precedence than `or`, that will cause the logic go to wrong section which lead the filename suffix to be el8 for gpdb6.

Authored-by: Ning Wu <ningw@vmware.com>