### PR TITLE
Fix the rpm filename wrong for gpdb7

### DIFF
--- a/ci/concourse/oss/base.py
+++ b/ci/concourse/oss/base.py
@@ -12,11 +12,13 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 from oss.utils import Util
+import semver
 
 
 class BasePackageBuilder(object):
     def __init__(self, bin_gpdb_path):
         self._gpdb_version_short = None
+        self._gpdb_major_version = None
         self.bin_gpdb_path = bin_gpdb_path
 
     @property
@@ -24,6 +26,12 @@ class BasePackageBuilder(object):
         if self._gpdb_version_short is None:
             self._gpdb_version_short = Util.extract_gpdb_version(self.bin_gpdb_path)
         return self._gpdb_version_short
+
+    @property
+    def gpdb_major_version(self):
+        ver = semver.Version.parse(self.gpdb_version_short)
+        self._gpdb_major_version = ver.major
+        return self._gpdb_major_version
 
     def build(self):
         pass

--- a/ci/concourse/oss/rpmbuild.py
+++ b/ci/concourse/oss/rpmbuild.py
@@ -89,7 +89,7 @@ class RPMPackageBuilder(BasePackageBuilder):
 
     @property
     def rpm_package_name(self):
-        if (self.platform == "rhel8" or self.platform == "rocky8" or self.platform == "oel8") and self.gpdb_version_short == "7":
+        if (self.platform == "rhel8" or self.platform == "rocky8" or self.platform == "oel8") and self.gpdb_major_version == 7:
             platform = "el8"
         else:
             platform = self.platform

--- a/ci/concourse/tasks/build-gpdb-rpm.yml
+++ b/ci/concourse/tasks/build-gpdb-rpm.yml
@@ -33,6 +33,7 @@ run:
   - -ec
   - |
     export PYTHONPATH=greenplum-database-release/ci/concourse/
+    pip3 install semver
     python greenplum-database-release/ci/concourse/scripts/build-gpdb-rpm.py
 
 params:


### PR DESCRIPTION
The `gpdb_version_short` is the full version (e.g 7.99.99), should use the major version to check. 

[GPR-1301]

Authored-by: Ning Wu <ningw@vmware.com>