### PR TITLE
Fix create_gpdb_clients_deb_installer_ubuntu18.04

### DIFF
--- a/ci/concourse/scripts/build-gpdb-clients-deb.bash
+++ b/ci/concourse/scripts/build-gpdb-clients-deb.bash
@@ -78,6 +78,11 @@ function _main() {
 	if [[ -z "${GPDB_VERSION}" ]]; then
 		set_gpdb_clients_version
 	fi
+
+	if [ -z "${GPDB_MAJOR_VERSION}"]; then
+		export GPDB_MAJOR_VERSION=$(echo "${GPDB_VERSION}" | cut -c 1)
+	fi
+
 	__gpdb_clients_version="${GPDB_VERSION}"
 	echo "[INFO] Building deb installer for GPDB clients version: ${__gpdb_clients_version}"
 


### PR DESCRIPTION
"build-gpdb-clients-deb.bash" was not set up to handle versions like "6.99.99" or "7.99.99", now it will.

[GPR-1386]

Authored-by: Lucas Bonner <blucas@vmware.com>