### PR TITLE
Add python3 to GP7 RPM dependencies

### DIFF
--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -48,6 +48,7 @@ Requires: openssh-clients
 Requires: openssh-server
 Requires: openssl
 Requires: perl
+Requires: python3
 Requires: python39
 Requires: readline
 Requires: rsync


### PR DESCRIPTION
From beta4, the management utilities depend on the system default
python3, which is python3.6 for el8; plpython depends on the python3.9.

So both of them need to be in the dependencies list.
https://jira.eng.vmware.com/projects/GPEX/issues/GPEX-95?filter=allopenissues
