### PR TITLE
Add python3-psycopg2 as a dependency for gpdb7 and its clients.

### DIFF
--- a/ci/concourse/scripts/gpdb-7-clients.spec
+++ b/ci/concourse/scripts/gpdb-7-clients.spec
@@ -40,6 +40,7 @@ Requires: bzip2
 Requires: libedit
 Requires: python3
 Requires: python39
+Requires: python3-psycopg2
 %if 0%{?rhel}
 Requires: libyaml
 Requires: libzstd

--- a/ci/concourse/scripts/greenplum-db-7-clients-control
+++ b/ci/concourse/scripts/greenplum-db-7-clients-control
@@ -19,6 +19,7 @@ Depends: libapr1,
     libzstd-dev,
     python3,
     python39,
+    python3-psycopg2
     zlib1g,
     libldap-2.4-2,
     openssh-client,

--- a/ci/concourse/scripts/greenplum-db-7-control
+++ b/ci/concourse/scripts/greenplum-db-7-control
@@ -23,6 +23,7 @@ Depends: libapr1,
     openssl,
     perl,
     python3,
+    python3-psycopg2
     python39,
     rsync,
     sed,

--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -50,6 +50,7 @@ Requires: openssl
 Requires: perl
 Requires: python3
 Requires: python39
+Requires: python3-psycopg2
 Requires: readline
 Requires: rsync
 Requires: sed


### PR DESCRIPTION
We're replacing pygresql with psycopg2 for gpdb7, since many OS provide psycopg2 in their systems' package managers. We don't need to vendor it ourselves. This patch helps add python3-psycopg2 as dependencies of rpm installer and deb installer.

Relevant PR:
- https://github.com/greenplum-db/gpdb/pull/15988
- https://github.com/greenplum-db/gpdb/pull/16001