### PR TITLE
Use system provided libzstd on EL9

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -70,6 +70,9 @@ Requires: compat-openssl11
 Requires: libevent
 # it is required by libxerces-c-3.1.so
 Requires: libicu-devel
+# EL 9 does have rsync version which not compatible with our built libzstd 1.3.7,
+# so EL 9 does not use our built libzstd but use system provided libzstd.
+Requires: libzstd
 %endif
 %if "%{platform}" == "rhel8" || "%{platform}" == "rocky8" || "%{platform}" == "oel8"
 Requires: openssl-libs


### PR DESCRIPTION
On EL9, system provided rsync and our built libzstd 1.3.7 is not compatible, it will error like:
/bin/rsync: undefined symbol: ZSTD_compressStream2

So we unvendor our bulit libzstd 1.3.7 for gpdb6, and require system provided libzstd instead

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>