### PR TITLE
Remove llvm-libs as required as it is now vendored

### DIFF
--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -60,7 +60,6 @@ Requires: tar
 Requires: which
 Requires: zip
 Requires: zlib
-Requires: llvm-libs
 Requires: libuuid
 %endif
 


### PR DESCRIPTION
[GPR-1494]

Authored-by: Lucas Bonner <blucas@vmware.com>