### PR TITLE
Revert "Remove llvm-libs as required as it is now vendored"

### DIFF
--- a/ci/concourse/scripts/greenplum-db-7.spec
+++ b/ci/concourse/scripts/greenplum-db-7.spec
@@ -60,6 +60,7 @@ Requires: tar
 Requires: which
 Requires: zip
 Requires: zlib
+Requires: llvm-libs
 Requires: libuuid
 %endif
 


### PR DESCRIPTION
Reverts greenplum-db/greenplum-database-release#304