### PR TITLE
Adding temporary ignore LLVM until vendored for GP7

### DIFF
--- a/ci/concourse/scripts/test-package-dependencies.bash
+++ b/ci/concourse/scripts/test-package-dependencies.bash
@@ -88,6 +88,11 @@ for j in "${missing_deps[@]}"; do
 			echo "Shared library $j missing"
 			exit 1
 		fi
+	elif [[ "${GPDB_MAJOR_VERSION}" == "7" ]]; then
+		if [[ $j != "libLLVM-15.so" ]]; then
+			echo "Shared library $j missing"
+			exit 1
+		fi
 	else
 		echo "Shared library $j missing"
 		exit 1


### PR DESCRIPTION


Authored-by: Lucas Bonner <blucas@vmware.com>