### PR TITLE
Remove libicu for gpdb6 EL9 deps

### DIFF
--- a/ci/concourse/scripts/greenplum-db-6.spec
+++ b/ci/concourse/scripts/greenplum-db-6.spec
@@ -68,8 +68,6 @@ Requires: libuuid
 # Also rocky9 does not have any cgroup package
 Requires: compat-openssl11
 Requires: libevent
-# it is required by libxerces-c-3.1.so
-Requires: libicu-devel
 # EL 9 does have rsync version which not compatible with our built libzstd 1.3.7,
 # so EL 9 does not use our built libzstd but use system provided libzstd.
 Requires: libzstd


### PR DESCRIPTION
We have rebuilt xerces for gpdb6 EL9 to remove the runtime deps for libicu, so Xerces won't need the libicu as a runtime dependency.

[GPR-1528]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>