### PR TITLE
Adding compat-openssl11 for el9 clients to fix missing libssl dependency

### DIFF
--- a/ci/concourse/scripts/gpdb-7-clients.spec
+++ b/ci/concourse/scripts/gpdb-7-clients.spec
@@ -55,6 +55,9 @@ Requires: libevent2
 %else
 Requires: libevent
 %endif
+%if 0%{?rhel} == 9
+Requires: compat-openssl11
+%endif
 
 %define bin_gpdb %{prefix}/%{name}-%{gpdb_clients_version}
 %description


### PR DESCRIPTION
[GPR-1586]

Authored-by: Lucas Bonner <blucas@vmware.com>